### PR TITLE
feat: improve menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -29,6 +29,8 @@ mod imp {
             // Set up keyboard shortcuts
             app.set_accels_for_action("win.quit", &["<Control>q"]);
             app.set_accels_for_action("win.show-shortcuts", &["<Control>question"]);
+            app.set_accels_for_action("win.preferences", &["<Control>comma"]);
+            app.set_accels_for_action("win.about", &["F1"]);
 
             let window = AsusctlGuiWindow::new(app);
             window.present();

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -230,9 +230,13 @@ impl AsusctlGuiWindow {
         let buttons_section = gio::Menu::new();
         buttons_section.append(Some("Preferences"), Some("win.preferences"));
         buttons_section.append(Some("Keyboard Shortcuts"), Some("win.show-shortcuts"));
-        buttons_section.append(Some("Quit"), Some("win.quit"));
         buttons_section.append(Some("About"), Some("win.about"));
         menu.append_section(None, &buttons_section);
+
+        // Quit section
+        let quit_section = gio::Menu::new();
+        quit_section.append(Some("Quit"), Some("win.quit"));
+        menu.append_section(None, &quit_section);
 
         let menu_button = gtk4::MenuButton::builder()
             .icon_name("open-menu-symbolic")
@@ -374,11 +378,13 @@ impl AsusctlGuiWindow {
 
         // Create section with items
         let section = adw::ShortcutsSection::new(Some("General"));
-        section.add(adw::ShortcutsItem::new("Quit", "<Control>q"));
+        section.add(adw::ShortcutsItem::new("Preferences", "<Control>comma"));
         section.add(adw::ShortcutsItem::new(
             "Keyboard Shortcuts",
             "<Control>question",
         ));
+        section.add(adw::ShortcutsItem::new("About", "F1"));
+        section.add(adw::ShortcutsItem::new("Quit", "<Control>q"));
 
         shortcuts.add(section);
         shortcuts.present(Some(self));


### PR DESCRIPTION
## Summary

- Add keyboard shortcuts for "Preferences" (`Ctrl+,`) and "About" (`F1`)
- Move "Quit" to separated menu section

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img width="332" height="297" alt="Before" src="https://github.com/user-attachments/assets/4c4a84d4-57b1-4dcc-948b-43c7dcbff261" /></td>
<td><img width="332" height="297" alt="After" src="https://github.com/user-attachments/assets/f2893f61-21dd-41ac-8475-bad90c702823" /></td>
</tr>
</table>
