### PR TITLE
fix: update cli commands for asusctl 6.3.2

### DIFF
--- a/src/backend/aura.rs
+++ b/src/backend/aura.rs
@@ -116,7 +116,7 @@ pub fn set_aura_mode(
     let speed_str = speed.map(|s| s.to_string());
     let direction_str = direction.map(|d| d.to_string());
 
-    let mut args: Vec<&str> = vec!["aura", mode_name];
+    let mut args: Vec<&str> = vec!["aura", "effect", mode_name];
 
     if mode.needs_colour() {
         let c = colour.ok_or_else(|| {
@@ -152,7 +152,7 @@ pub fn set_aura_mode(
 
 /// Fetch the help text for a given aura mode from the CLI.
 pub fn get_aura_mode_help(mode: AuraMode) -> Option<String> {
-    run_asusctl(&["aura", mode.cli_name(), "--help"])
+    run_asusctl(&["aura", "effect", mode.cli_name(), "--help"])
         .ok()
         .map(|s| s.trim().to_string())
 }

--- a/src/backend/system.rs
+++ b/src/backend/system.rs
@@ -76,14 +76,18 @@ fn parse_supported_features(output: &str) -> Result<SupportedFeatures> {
     for mode_name in [
         "Static",
         "Breathe",
-        "Pulse",
         "RainbowCycle",
         "RainbowWave",
+        "Stars",
+        "Rain",
         "Highlight",
+        "Laser",
+        "Ripple",
+        "Pulse",
+        "Comet",
+        "Flash",
     ] {
         if aura_section.contains(mode_name) {
-            // Modes without a CLI subcommand (e.g. Pulse) will fail to parse
-            // and be silently skipped.
             if let Ok(aura_mode) = AuraMode::from_str(mode_name) {
                 if !features.aura_modes.contains(&aura_mode) {
                     features.aura_modes.push(aura_mode);

--- a/src/backend/types.rs
+++ b/src/backend/types.rs
@@ -99,18 +99,32 @@ pub enum AuraMode {
     Breathe,
     RainbowCycle,
     RainbowWave,
+    Stars,
+    Rain,
     Highlight,
+    Laser,
+    Ripple,
+    Pulse,
+    Comet,
+    Flash,
 }
 
 impl AuraMode {
-    /// Returns the CLI subcommand name for `asusctl aura <mode>`
+    /// Returns the CLI subcommand name for `asusctl aura effect <mode>`
     pub fn cli_name(&self) -> &'static str {
         match self {
             Self::Static => "static",
             Self::Breathe => "breathe",
             Self::RainbowCycle => "rainbow-cycle",
             Self::RainbowWave => "rainbow-wave",
+            Self::Stars => "stars",
+            Self::Rain => "rain",
             Self::Highlight => "highlight",
+            Self::Laser => "laser",
+            Self::Ripple => "ripple",
+            Self::Pulse => "pulse",
+            Self::Comet => "comet",
+            Self::Flash => "flash",
         }
     }
 
@@ -120,7 +134,14 @@ impl AuraMode {
         Self::Breathe,
         Self::RainbowCycle,
         Self::RainbowWave,
+        Self::Stars,
+        Self::Rain,
         Self::Highlight,
+        Self::Laser,
+        Self::Ripple,
+        Self::Pulse,
+        Self::Comet,
+        Self::Flash,
     ];
 
     /// Short UI label (matches CLI subcommand names)
@@ -130,25 +151,50 @@ impl AuraMode {
             Self::Breathe => "Breathe",
             Self::RainbowCycle => "Rainbow Cycle",
             Self::RainbowWave => "Rainbow Wave",
+            Self::Stars => "Stars",
+            Self::Rain => "Rain",
             Self::Highlight => "Highlight",
+            Self::Laser => "Laser",
+            Self::Ripple => "Ripple",
+            Self::Pulse => "Pulse",
+            Self::Comet => "Comet",
+            Self::Flash => "Flash",
         }
     }
 
     /// Whether this mode requires a colour parameter
     pub fn needs_colour(&self) -> bool {
-        matches!(self, Self::Static | Self::Breathe | Self::Highlight)
+        matches!(
+            self,
+            Self::Static
+                | Self::Breathe
+                | Self::Stars
+                | Self::Highlight
+                | Self::Laser
+                | Self::Ripple
+                | Self::Pulse
+                | Self::Comet
+                | Self::Flash
+        )
     }
 
     /// Whether this mode requires a second colour parameter
     pub fn needs_colour2(&self) -> bool {
-        matches!(self, Self::Breathe)
+        matches!(self, Self::Breathe | Self::Stars)
     }
 
     /// Whether this mode requires a speed parameter
     pub fn needs_speed(&self) -> bool {
         matches!(
             self,
-            Self::Breathe | Self::RainbowCycle | Self::RainbowWave | Self::Highlight
+            Self::Breathe
+                | Self::RainbowCycle
+                | Self::RainbowWave
+                | Self::Stars
+                | Self::Rain
+                | Self::Highlight
+                | Self::Laser
+                | Self::Ripple
         )
     }
 
@@ -166,9 +212,15 @@ impl AuraMode {
         match value {
             0 => Some(Self::Static),
             1 => Some(Self::Breathe),
-            3 => Some(Self::RainbowCycle), // Rainbow in asusd
-            4 => Some(Self::RainbowWave),  // Star/RainbowWave in some versions
+            3 => Some(Self::RainbowCycle),
+            4 => Some(Self::Stars),
+            5 => Some(Self::Rain),
             6 => Some(Self::Highlight),
+            7 => Some(Self::Laser),
+            8 => Some(Self::Ripple),
+            9 => Some(Self::Pulse),
+            10 => Some(Self::Comet),
+            11 => Some(Self::Flash),
             _ => None,
         }
     }
@@ -181,7 +233,14 @@ impl std::fmt::Display for AuraMode {
             Self::Breathe => write!(f, "Breathe"),
             Self::RainbowCycle => write!(f, "Rainbow Cycle"),
             Self::RainbowWave => write!(f, "Rainbow Wave"),
+            Self::Stars => write!(f, "Stars"),
+            Self::Rain => write!(f, "Rain"),
             Self::Highlight => write!(f, "Highlight"),
+            Self::Laser => write!(f, "Laser"),
+            Self::Ripple => write!(f, "Ripple"),
+            Self::Pulse => write!(f, "Pulse"),
+            Self::Comet => write!(f, "Comet"),
+            Self::Flash => write!(f, "Flash"),
         }
     }
 }
@@ -195,7 +254,14 @@ impl FromStr for AuraMode {
             "breathe" => Ok(Self::Breathe),
             "rainbow-cycle" | "rainbowcycle" | "rainbow cycle" => Ok(Self::RainbowCycle),
             "rainbow-wave" | "rainbowwave" | "rainbow wave" => Ok(Self::RainbowWave),
+            "stars" => Ok(Self::Stars),
+            "rain" => Ok(Self::Rain),
             "highlight" => Ok(Self::Highlight),
+            "laser" => Ok(Self::Laser),
+            "ripple" => Ok(Self::Ripple),
+            "pulse" => Ok(Self::Pulse),
+            "comet" => Ok(Self::Comet),
+            "flash" => Ok(Self::Flash),
             _ => Err(AsusctlError::ParseError(format!("Unknown aura mode: {s}"))),
         }
     }
@@ -286,6 +352,7 @@ pub struct AuraModeData {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SlashMode {
+    Static,
     Bounce,
     Slash,
     Loading,
@@ -307,6 +374,7 @@ pub enum SlashMode {
 impl std::fmt::Display for SlashMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Static => write!(f, "Static"),
             Self::Bounce => write!(f, "Bounce"),
             Self::Slash => write!(f, "Slash"),
             Self::Loading => write!(f, "Loading"),
@@ -331,6 +399,7 @@ impl FromStr for SlashMode {
 
     fn from_str(s: &str) -> Result<Self> {
         match s {
+            "Static" => Ok(Self::Static),
             "Bounce" => Ok(Self::Bounce),
             "Slash" => Ok(Self::Slash),
             "Loading" => Ok(Self::Loading),

--- a/src/ui/pages/aura.rs
+++ b/src/ui/pages/aura.rs
@@ -372,7 +372,7 @@ impl AuraPage {
         // Second color row (for Breathe mode)
         let color2_row = adw::ActionRow::builder()
             .title("Second Color")
-            .subtitle("Breathing target color")
+            .subtitle("Secondary effect color")
             .build();
 
         let color2_dialog = gtk4::ColorDialog::builder().build();

--- a/src/ui/pages/slash.rs
+++ b/src/ui/pages/slash.rs
@@ -53,6 +53,7 @@ glib::wrapper! {
 
 // Mode names in order (index matches SlashMode enum variant order)
 const SLASH_MODES: &[(&str, &str)] = &[
+    ("Static", "Static light effect"),
     ("Bounce", "Bouncing light effect"),
     ("Slash", "Slashing light animation"),
     ("Loading", "Progress bar style animation"),
@@ -195,21 +196,22 @@ impl SlashPage {
                     return;
                 }
                 let mode = match combo.selected() {
-                    0 => SlashMode::Bounce,
-                    1 => SlashMode::Slash,
-                    2 => SlashMode::Loading,
-                    3 => SlashMode::BitStream,
-                    4 => SlashMode::Transmission,
-                    5 => SlashMode::Flow,
-                    6 => SlashMode::Flux,
-                    7 => SlashMode::Phantom,
-                    8 => SlashMode::Spectrum,
-                    9 => SlashMode::Hazard,
-                    10 => SlashMode::Interfacing,
-                    11 => SlashMode::Ramp,
-                    12 => SlashMode::GameOver,
-                    13 => SlashMode::Start,
-                    14 => SlashMode::Buzzer,
+                    0 => SlashMode::Static,
+                    1 => SlashMode::Bounce,
+                    2 => SlashMode::Slash,
+                    3 => SlashMode::Loading,
+                    4 => SlashMode::BitStream,
+                    5 => SlashMode::Transmission,
+                    6 => SlashMode::Flow,
+                    7 => SlashMode::Flux,
+                    8 => SlashMode::Phantom,
+                    9 => SlashMode::Spectrum,
+                    10 => SlashMode::Hazard,
+                    11 => SlashMode::Interfacing,
+                    12 => SlashMode::Ramp,
+                    13 => SlashMode::GameOver,
+                    14 => SlashMode::Start,
+                    15 => SlashMode::Buzzer,
                     _ => return,
                 };
 
@@ -394,21 +396,22 @@ impl SlashPage {
             match backend::get_slash_mode() {
                 Ok(mode) => {
                     let index = match mode {
-                        SlashMode::Bounce => 0,
-                        SlashMode::Slash => 1,
-                        SlashMode::Loading => 2,
-                        SlashMode::BitStream => 3,
-                        SlashMode::Transmission => 4,
-                        SlashMode::Flow => 5,
-                        SlashMode::Flux => 6,
-                        SlashMode::Phantom => 7,
-                        SlashMode::Spectrum => 8,
-                        SlashMode::Hazard => 9,
-                        SlashMode::Interfacing => 10,
-                        SlashMode::Ramp => 11,
-                        SlashMode::GameOver => 12,
-                        SlashMode::Start => 13,
-                        SlashMode::Buzzer => 14,
+                        SlashMode::Static => 0,
+                        SlashMode::Bounce => 1,
+                        SlashMode::Slash => 2,
+                        SlashMode::Loading => 3,
+                        SlashMode::BitStream => 4,
+                        SlashMode::Transmission => 5,
+                        SlashMode::Flow => 6,
+                        SlashMode::Flux => 7,
+                        SlashMode::Phantom => 8,
+                        SlashMode::Spectrum => 9,
+                        SlashMode::Hazard => 10,
+                        SlashMode::Interfacing => 11,
+                        SlashMode::Ramp => 12,
+                        SlashMode::GameOver => 13,
+                        SlashMode::Start => 14,
+                        SlashMode::Buzzer => 15,
                     };
                     combo.set_selected(index);
                 }


### PR DESCRIPTION
## Summary
- Fix aura effect commands (`asusctl aura <mode>` → `asusctl aura effect <mode>`)
- Add all missing aura modes: Stars, Rain, Laser, Ripple, Pulse, Comet, Flash
- Add Slash `Static` mode (closes #9)
- Fix D-Bus AuraMode value mapping

## Test plan
- [x] Verify aura mode changes apply correctly via `asusctl aura effect`
- [x] Verify slash Static mode can be selected and applied
- [x] Verify supported modes are detected from `asusctl info --show-supported`