### PR TITLE
fix: handle unsupported features and non-asus devices

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -34,7 +34,7 @@ pub use types::{
 };
 
 // Re-export system functions
-pub use system::{get_supported_features, get_system_info};
+pub use system::{detect_features, get_system_info};
 
 // Re-export aura functions
 pub use aura::{

--- a/src/backend/system.rs
+++ b/src/backend/system.rs
@@ -1,10 +1,16 @@
 //! System information and feature detection.
 
 use std::str::FromStr;
+use std::sync::OnceLock;
 
-use super::dbus::run_asusctl;
-use super::error::Result;
+use super::dbus::{
+    get_aura_path, get_slash_path, read_dbus_property_at, run_asusctl, PLATFORM_INTERFACE,
+    PLATFORM_PATH,
+};
+use super::error::{AsusctlError, Result};
 use super::types::{AuraMode, KeyboardBrightness, SupportedFeatures, SystemInfo};
+
+static DETECTED_FEATURES: OnceLock<SupportedFeatures> = OnceLock::new();
 
 // ============================================================================
 // Public API
@@ -16,10 +22,81 @@ pub fn get_system_info() -> Result<SystemInfo> {
     parse_system_info(&output)
 }
 
-/// Get supported features for this laptop.
-pub fn get_supported_features() -> Result<SupportedFeatures> {
-    let output = run_asusctl(&["info", "--show-supported"])?;
-    parse_supported_features(&output)
+/// Detect available features once and cache the result for the process lifetime.
+///
+/// Tries `asusctl info --show-supported` first for the richest data.
+/// Falls back to D-Bus probing when asusctl is not installed or the service
+/// is not running.
+pub fn detect_features() -> &'static SupportedFeatures {
+    DETECTED_FEATURES.get_or_init(|| {
+        let mut features = SupportedFeatures::default();
+
+        match run_asusctl(&["info", "--show-supported"]) {
+            Ok(output) => {
+                features.asusctl_installed = true;
+                features.asusd_running = true;
+                if let Ok(parsed) = parse_supported_features(&output) {
+                    let asusctl_installed = true;
+                    let asusd_running = true;
+                    features = parsed;
+                    features.asusctl_installed = asusctl_installed;
+                    features.asusd_running = asusd_running;
+                }
+            }
+            Err(AsusctlError::NotInstalled) => {
+                features.asusctl_installed = false;
+                probe_dbus_features(&mut features);
+            }
+            Err(AsusctlError::ServiceNotRunning) => {
+                features.asusctl_installed = true;
+                features.asusd_running = false;
+                probe_dbus_features(&mut features);
+            }
+            Err(_) => {
+                features.asusctl_installed = true;
+                probe_dbus_features(&mut features);
+            }
+        }
+
+        eprintln!(
+            "[asusctl-gui] Feature detection: asusctl={}, asusd={}, aura={}, platform={}, slash={}, charge_control={}, modes={}",
+            features.asusctl_installed,
+            features.asusd_running,
+            features.has_aura,
+            features.has_platform,
+            features.has_slash,
+            features.has_charge_control,
+            features.aura_modes.len(),
+        );
+
+        features
+    })
+}
+
+/// Probe D-Bus to discover available features without the asusctl CLI.
+fn probe_dbus_features(features: &mut SupportedFeatures) {
+    if get_aura_path().is_some() {
+        features.has_aura = true;
+    }
+
+    if get_slash_path().is_some() {
+        features.has_slash = true;
+    }
+
+    if read_dbus_property_at(PLATFORM_PATH, PLATFORM_INTERFACE, "ChargeControlEndThreshold")
+        .is_ok()
+    {
+        features.has_platform = true;
+        features.has_charge_control = true;
+    }
+    if read_dbus_property_at(PLATFORM_PATH, PLATFORM_INTERFACE, "ThrottlePolicy").is_ok() {
+        features.has_platform = true;
+        features.has_throttle_policy = true;
+    }
+
+    if features.has_aura || features.has_slash || features.has_platform {
+        features.asusd_running = true;
+    }
 }
 
 // ============================================================================

--- a/src/backend/types.rs
+++ b/src/backend/types.rs
@@ -434,6 +434,8 @@ pub struct SlashState {
 
 #[derive(Debug, Clone, Default)]
 pub struct SupportedFeatures {
+    pub asusctl_installed: bool,
+    pub asusd_running: bool,
     pub has_aura: bool,
     pub has_platform: bool,
     pub has_fan_curves: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,9 @@ use gtk4::gio;
 use gtk4::prelude::*;
 
 fn main() -> gtk4::glib::ExitCode {
+    // Detect available features early so the OnceLock is warm before UI construction
+    backend::detect_features();
+
     // Register resources (this is fine before init)
     gio::resources_register_include!("asusctl-gui.gresource")
         .expect("Failed to register resources.");

--- a/src/ui/pages/about.rs
+++ b/src/ui/pages/about.rs
@@ -98,23 +98,13 @@ impl AboutPage {
 
         self.append(&laptop_group);
 
-        // Supported features group (loaded once, static data)
+        // Supported features group (loaded once from cached detection)
         let features_group = adw::PreferencesGroup::builder()
             .title("Supported Features")
             .build();
 
-        match backend::get_supported_features() {
-            Ok(features) => {
-                Self::populate_features(&features_group, &features);
-            }
-            Err(e) => {
-                let error_row = adw::ActionRow::builder()
-                    .title("Error loading features")
-                    .subtitle(&e.to_string())
-                    .build();
-                features_group.add(&error_row);
-            }
-        }
+        let features = backend::detect_features();
+        Self::populate_features(&features_group, features);
 
         self.append(&features_group);
     }
@@ -152,6 +142,32 @@ impl AboutPage {
     }
 
     fn populate_features(group: &adw::PreferencesGroup, features: &backend::SupportedFeatures) {
+        // Service status
+        let service_status = [
+            ("asusctl Installed", features.asusctl_installed),
+            ("asusd Service Running", features.asusd_running),
+        ];
+
+        for (name, available) in service_status {
+            let row = adw::ActionRow::builder().title(name).build();
+
+            let icon_name = if available {
+                "object-select-symbolic"
+            } else {
+                "window-close-symbolic"
+            };
+
+            let icon = gtk4::Image::from_icon_name(icon_name);
+            if available {
+                icon.add_css_class("success");
+            } else {
+                icon.add_css_class("error");
+            }
+            row.add_suffix(&icon);
+
+            group.add(&row);
+        }
+
         // Core features
         let core_features = [
             ("Aura (Keyboard Lighting)", features.has_aura),

--- a/src/ui/pages/aura.rs
+++ b/src/ui/pages/aura.rs
@@ -13,6 +13,7 @@ mod imp {
 
     #[derive(Debug, Default)]
     pub struct AuraPage {
+        pub available: RefCell<bool>,
         pub brightness_buttons: RefCell<Vec<gtk4::ToggleButton>>,
         pub mode_buttons: RefCell<Vec<(gtk4::ToggleButton, AuraMode)>>,
         pub speed_buttons: RefCell<Vec<(gtk4::ToggleButton, AuraSpeed)>>,
@@ -67,18 +68,32 @@ impl AuraPage {
 
     fn setup_ui(&self) {
         let imp = self.imp();
+        let features = backend::detect_features();
 
-        // Query supported features from asusctl
-        let supported = backend::get_supported_features().ok();
-        let supported_modes: Vec<AuraMode> = supported
-            .as_ref()
-            .map(|s| s.aura_modes.clone())
-            .filter(|m| !m.is_empty())
-            .unwrap_or_else(|| AuraMode::ALL.to_vec());
-        let supported_zones: Vec<String> = supported
-            .as_ref()
-            .map(|s| s.aura_zones.clone())
-            .unwrap_or_default();
+        if !features.has_aura {
+            *imp.available.borrow_mut() = false;
+            let status = adw::StatusPage::builder()
+                .icon_name("keyboard-brightness-symbolic")
+                .title("Aura Lighting Unavailable")
+                .description(if !features.asusctl_installed {
+                    "asusctl is not installed. Install asusctl to control keyboard lighting."
+                } else {
+                    "Aura keyboard lighting is not supported on this device, or the asusd service is not running."
+                })
+                .vexpand(true)
+                .build();
+            self.append(&status);
+            return;
+        }
+
+        *imp.available.borrow_mut() = true;
+
+        let supported_modes: Vec<AuraMode> = if features.aura_modes.is_empty() {
+            vec![AuraMode::Static]
+        } else {
+            features.aura_modes.clone()
+        };
+        let supported_zones: Vec<String> = features.aura_zones.clone();
 
         // Page title
         let title = gtk4::Label::builder()
@@ -487,6 +502,10 @@ impl AuraPage {
     /// Refresh/reload all data on this page
     fn refresh_data(&self) {
         let imp = self.imp();
+
+        if !*imp.available.borrow() {
+            return;
+        }
 
         *imp.refreshing.borrow_mut() = true;
 

--- a/src/ui/pages/power.rs
+++ b/src/ui/pages/power.rs
@@ -13,6 +13,8 @@ mod imp {
 
     #[derive(Debug, Default)]
     pub struct PowerPage {
+        pub available: RefCell<bool>,
+        pub charge_control_available: RefCell<bool>,
         pub profile_radios: RefCell<Vec<gtk4::CheckButton>>,
         pub ac_combo: RefCell<Option<adw::ComboRow>>,
         pub battery_combo: RefCell<Option<adw::ComboRow>>,
@@ -59,6 +61,22 @@ impl PowerPage {
 
     fn setup_ui(&self) {
         let imp = self.imp();
+        let features = backend::detect_features();
+
+        if !features.asusctl_installed {
+            *imp.available.borrow_mut() = false;
+            let status = adw::StatusPage::builder()
+                .icon_name("gnome-power-manager-symbolic")
+                .title("Power Profiles Unavailable")
+                .description("asusctl is not installed. Install asusctl to manage power profiles and charge control.")
+                .vexpand(true)
+                .build();
+            self.append(&status);
+            return;
+        }
+
+        *imp.available.borrow_mut() = true;
+        *imp.charge_control_available.borrow_mut() = features.has_charge_control;
 
         // Page title
         let title = gtk4::Label::builder()
@@ -220,48 +238,54 @@ impl PowerPage {
         battery_group.add(&battery_combo);
         self.append(&battery_group);
 
-        // Battery settings group
-        let battery_settings = adw::PreferencesGroup::builder()
-            .title("Battery Settings")
-            .build();
+        // Battery settings group (only if charge control is supported)
+        if features.has_charge_control {
+            let battery_settings = adw::PreferencesGroup::builder()
+                .title("Battery Settings")
+                .build();
 
-        let charge_limit_row = adw::ActionRow::builder()
-            .title("Charge Limit")
-            .subtitle("Limit maximum charge to extend battery lifespan")
-            .build();
+            let charge_limit_row = adw::ActionRow::builder()
+                .title("Charge Limit")
+                .subtitle("Limit maximum charge to extend battery lifespan")
+                .build();
 
-        let charge_scale = gtk4::Scale::builder()
-            .orientation(gtk4::Orientation::Horizontal)
-            .adjustment(&gtk4::Adjustment::new(80.0, 20.0, 100.0, 5.0, 10.0, 0.0))
-            .width_request(200)
-            .valign(gtk4::Align::Center)
-            .draw_value(true)
-            .build();
+            let charge_scale = gtk4::Scale::builder()
+                .orientation(gtk4::Orientation::Horizontal)
+                .adjustment(&gtk4::Adjustment::new(80.0, 20.0, 100.0, 5.0, 10.0, 0.0))
+                .width_request(200)
+                .valign(gtk4::Align::Center)
+                .draw_value(true)
+                .build();
 
-        // Connect charge scale to set charge limit
-        {
-            let this = self.clone();
-            charge_scale.connect_value_changed(move |scale| {
-                if *this.imp().refreshing.borrow() {
-                    return;
-                }
-                let value = scale.value() as u8;
-                if let Err(e) = backend::set_charge_limit(value) {
-                    eprintln!("Failed to set charge limit: {e}");
-                }
-            });
+            // Connect charge scale to set charge limit
+            {
+                let this = self.clone();
+                charge_scale.connect_value_changed(move |scale| {
+                    if *this.imp().refreshing.borrow() {
+                        return;
+                    }
+                    let value = scale.value() as u8;
+                    if let Err(e) = backend::set_charge_limit(value) {
+                        eprintln!("Failed to set charge limit: {e}");
+                    }
+                });
+            }
+
+            imp.charge_scale.replace(Some(charge_scale.clone()));
+            charge_limit_row.add_suffix(&charge_scale);
+            battery_settings.add(&charge_limit_row);
+
+            self.append(&battery_settings);
         }
-
-        imp.charge_scale.replace(Some(charge_scale.clone()));
-        charge_limit_row.add_suffix(&charge_scale);
-        battery_settings.add(&charge_limit_row);
-
-        self.append(&battery_settings);
     }
 
     /// Refresh/reload all data on this page
     fn refresh_data(&self) {
         let imp = self.imp();
+
+        if !*imp.available.borrow() {
+            return;
+        }
 
         *imp.refreshing.borrow_mut() = true;
 
@@ -304,14 +328,16 @@ impl PowerPage {
             }
         }
 
-        // Load charge limit via D-Bus
-        if let Some(scale) = imp.charge_scale.borrow().as_ref() {
-            match backend::get_charge_limit_dbus() {
-                Ok(limit) => {
-                    scale.set_value(limit as f64);
-                }
-                Err(e) => {
-                    eprintln!("Failed to get charge limit: {e}");
+        // Load charge limit via D-Bus (only if charge control is supported)
+        if *imp.charge_control_available.borrow() {
+            if let Some(scale) = imp.charge_scale.borrow().as_ref() {
+                match backend::get_charge_limit_dbus() {
+                    Ok(limit) => {
+                        scale.set_value(limit as f64);
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to get charge limit: {e}");
+                    }
                 }
             }
         }

--- a/src/ui/pages/slash.rs
+++ b/src/ui/pages/slash.rs
@@ -13,6 +13,7 @@ mod imp {
 
     #[derive(Debug, Default)]
     pub struct SlashPage {
+        pub available: RefCell<bool>,
         pub enable_switch: RefCell<Option<adw::SwitchRow>>,
         pub brightness_scale: RefCell<Option<gtk4::Scale>>,
         pub mode_combo: RefCell<Option<adw::ComboRow>>,
@@ -85,6 +86,25 @@ impl SlashPage {
 
     fn setup_ui(&self) {
         let imp = self.imp();
+        let features = backend::detect_features();
+
+        if !features.has_slash {
+            *imp.available.borrow_mut() = false;
+            let status = adw::StatusPage::builder()
+                .icon_name("display-brightness-symbolic")
+                .title("Slash Lighting Unavailable")
+                .description(if !features.asusctl_installed {
+                    "asusctl is not installed. Install asusctl to control the slash LED bar."
+                } else {
+                    "Slash LED bar is not supported on this device, or the asusd service is not running."
+                })
+                .vexpand(true)
+                .build();
+            self.append(&status);
+            return;
+        }
+
+        *imp.available.borrow_mut() = true;
 
         // Page title
         let title = gtk4::Label::builder()
@@ -358,6 +378,10 @@ impl SlashPage {
     /// Refresh/reload all data on this page
     fn refresh_data(&self) {
         let imp = self.imp();
+
+        if !*imp.available.borrow() {
+            return;
+        }
 
         // Set refreshing flag to prevent signal handlers from firing
         *imp.refreshing.borrow_mut() = true;


### PR DESCRIPTION
## Summary
- Detect available hardware features once at startup via `OnceLock` caching
- Show `adw::StatusPage` on pages where features are unavailable (Aura, Slash, Power)
- Guard refresh cycles to return early for unavailable features, eliminating repeated error spam
- Conditionally render charge control section based on feature detection
- Display service and feature status on the About page

Closes #12
