### PR TITLE
feat: add custom rainbow effect with adjustable speed

### DIFF
--- a/resources/com.github.bl4ckspell7.asusctl-gui.gschema.xml
+++ b/resources/com.github.bl4ckspell7.asusctl-gui.gschema.xml
@@ -27,5 +27,10 @@
             <summary>Refresh interval</summary>
             <description>How often to refresh data from the system, in seconds (0.1-10.0)</description>
         </key>
+        <key name="rainbow-speed" type="u">
+            <default>5</default>
+            <summary>Rainbow effect speed</summary>
+            <description>Speed of the rainbow color cycle (1 = slowest, 10 = fastest)</description>
+        </key>
     </schema>
 </schemalist>

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -38,8 +38,8 @@ pub use system::{detect_features, get_system_info};
 
 // Re-export aura functions
 pub use aura::{
-    get_aura_mode_data_dbus, get_aura_mode_help, get_keyboard_brightness_dbus, set_aura_mode,
-    set_keyboard_brightness,
+    get_aura_mode_data_dbus, get_aura_mode_help, get_keyboard_brightness_dbus, is_rainbow_running,
+    set_aura_mode, set_keyboard_brightness, start_rainbow, stop_rainbow,
 };
 
 // Re-export power functions

--- a/src/backend/aura.rs
+++ b/src/backend/aura.rs
@@ -1,9 +1,10 @@
 //! Aura lighting and keyboard brightness control.
 
+use std::process::{Command, Stdio};
 use std::str::FromStr;
 
 use super::dbus::{
-    get_aura_path, parse_dbus_uint, read_dbus_property_at, run_asusctl, AURA_INTERFACE,
+    AURA_INTERFACE, get_aura_path, parse_dbus_uint, read_dbus_property_at, run_asusctl,
 };
 use super::error::{AsusctlError, Result};
 use super::types::{AuraDirection, AuraMode, AuraModeData, AuraSpeed, KeyboardBrightness};
@@ -120,27 +121,25 @@ pub fn set_aura_mode(
     let mut args: Vec<&str> = vec!["aura", "effect", mode_name];
 
     if mode.needs_colour() {
-        let c = colour.ok_or_else(|| {
-            AsusctlError::CommandFailed(format!("{mode} requires a colour"))
-        })?;
+        let c = colour
+            .ok_or_else(|| AsusctlError::CommandFailed(format!("{mode} requires a colour")))?;
         args.extend_from_slice(&["--colour", c]);
     }
     if mode.needs_colour2() {
-        let c2 = colour2.ok_or_else(|| {
-            AsusctlError::CommandFailed(format!("{mode} requires colour2"))
-        })?;
+        let c2 = colour2
+            .ok_or_else(|| AsusctlError::CommandFailed(format!("{mode} requires colour2")))?;
         args.extend_from_slice(&["--colour2", c2]);
     }
     if mode.needs_direction() {
-        let d = direction_str.as_deref().ok_or_else(|| {
-            AsusctlError::CommandFailed(format!("{mode} requires direction"))
-        })?;
+        let d = direction_str
+            .as_deref()
+            .ok_or_else(|| AsusctlError::CommandFailed(format!("{mode} requires direction")))?;
         args.extend_from_slice(&["--direction", d]);
     }
     if mode.needs_speed() {
-        let s = speed_str.as_deref().ok_or_else(|| {
-            AsusctlError::CommandFailed(format!("{mode} requires speed"))
-        })?;
+        let s = speed_str
+            .as_deref()
+            .ok_or_else(|| AsusctlError::CommandFailed(format!("{mode} requires speed")))?;
         args.extend_from_slice(&["--speed", s]);
     }
     if let Some(z) = zone {
@@ -157,6 +156,131 @@ pub fn get_aura_mode_help(mode: AuraMode) -> Option<String> {
     run_asusctl(&["aura", "effect", mode.cli_name(), "--help"])
         .ok()
         .map(|s| s.trim().to_string())
+}
+
+// ============================================================================
+// Public API - Custom Rainbow Effect
+// ============================================================================
+
+const RAINBOW_STEPS: u32 = 240;
+
+/// Get the path to the rainbow PID file.
+fn rainbow_pid_path() -> std::path::PathBuf {
+    let state_dir = std::env::var("XDG_STATE_HOME").unwrap_or_else(|_| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        format!("{home}/.local/state")
+    });
+    std::path::PathBuf::from(state_dir)
+        .join("asusctl-gui")
+        .join("rainbow.pid")
+}
+
+/// Check whether the rainbow process is currently running.
+pub fn is_rainbow_running() -> bool {
+    let pid_path = rainbow_pid_path();
+    let pid_str = match std::fs::read_to_string(&pid_path) {
+        Ok(s) => s.trim().to_string(),
+        Err(_) => return false,
+    };
+
+    if std::path::Path::new(&format!("/proc/{pid_str}")).exists() {
+        true
+    } else {
+        // Stale PID file, clean up
+        let _ = std::fs::remove_file(&pid_path);
+        false
+    }
+}
+
+/// Stop the rainbow process if it is running.
+pub fn stop_rainbow() -> Result<()> {
+    let pid_path = rainbow_pid_path();
+    let pid_str = match std::fs::read_to_string(&pid_path) {
+        Ok(s) => s.trim().to_string(),
+        Err(_) => return Ok(()),
+    };
+
+    let _ = Command::new("kill").arg(&pid_str).output();
+    let _ = std::fs::remove_file(&pid_path);
+    eprintln!("[asusctl-gui] Stopped rainbow effect");
+    Ok(())
+}
+
+/// Convert HSV to a hex RGB string.
+/// Hue: 0.0-360.0, Saturation: 0.0-1.0, Value: 0.0-1.0
+fn hsv_to_hex(h: f64, s: f64, v: f64) -> String {
+    let c = v * s;
+    let x = c * (1.0 - ((h / 60.0) % 2.0 - 1.0).abs());
+    let m = v - c;
+
+    let (r, g, b) = if h < 60.0 {
+        (c, x, 0.0)
+    } else if h < 120.0 {
+        (x, c, 0.0)
+    } else if h < 180.0 {
+        (0.0, c, x)
+    } else if h < 240.0 {
+        (0.0, x, c)
+    } else if h < 300.0 {
+        (x, 0.0, c)
+    } else {
+        (c, 0.0, x)
+    };
+
+    let r = ((r + m) * 255.0) as u8;
+    let g = ((g + m) * 255.0) as u8;
+    let b = ((b + m) * 255.0) as u8;
+
+    format!("{r:02x}{g:02x}{b:02x}")
+}
+
+/// Start the rainbow effect as a detached background process.
+///
+/// Precomputes all hex colors in Rust, then spawns a bash script via
+/// `setsid --fork` that cycles through them. The process survives app close.
+pub fn start_rainbow(speed: u32) -> Result<()> {
+    stop_rainbow()?;
+
+    let delay = 0.5 / (speed.max(1) as f64).powf(3.7);
+
+    // Precompute all rainbow colors
+    let colors: Vec<String> = (0..RAINBOW_STEPS)
+        .map(|i| {
+            let hue = i as f64 * 360.0 / RAINBOW_STEPS as f64;
+            hsv_to_hex(hue, 1.0, 1.0)
+        })
+        .collect();
+
+    let pid_path = rainbow_pid_path();
+    let pid_dir = pid_path.parent().unwrap();
+
+    std::fs::create_dir_all(pid_dir)
+        .map_err(|e| AsusctlError::CommandFailed(format!("Failed to create state dir: {e}")))?;
+
+    let colors_str = colors.join(" ");
+    let pid_path_str = pid_path.display();
+    let script = format!(
+        "P=\"{pid_path_str}\"\n\
+         trap 'rm -f \"$P\"' EXIT\n\
+         echo $$ > \"$P\"\n\
+         while true; do\n\
+         for c in {colors_str}; do\n\
+         asusctl aura effect static --colour \"$c\" 2>/dev/null\n\
+         sleep {delay:.6}\n\
+         done\n\
+         done"
+    );
+
+    Command::new("setsid")
+        .args(["--fork", "bash", "-c", &script])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|e| AsusctlError::CommandFailed(format!("Failed to start rainbow: {e}")))?;
+
+    eprintln!("[asusctl-gui] Started rainbow effect (speed={speed}, delay={delay:.6})");
+    Ok(())
 }
 
 // ============================================================================

--- a/src/ui/pages/aura.rs
+++ b/src/ui/pages/aura.rs
@@ -27,6 +27,11 @@ mod imp {
         pub zone_dropdown: RefCell<Option<gtk4::DropDown>>,
         pub selected_mode: RefCell<AuraMode>,
         pub refreshing: RefCell<bool>,
+        // Custom effects
+        pub mode_group: RefCell<Option<adw::PreferencesGroup>>,
+        pub color_group: RefCell<Option<adw::PreferencesGroup>>,
+        pub rainbow_switch: RefCell<Option<adw::SwitchRow>>,
+        pub rainbow_speed_scale: RefCell<Option<gtk4::Scale>>,
     }
 
     #[glib::object_subclass]
@@ -410,6 +415,94 @@ impl AuraPage {
 
         self.append(&color_group);
 
+        // Custom Effects group
+        let settings = gtk4::gio::Settings::new("com.github.bl4ckspell7.asusctl-gui");
+
+        let custom_group = adw::PreferencesGroup::builder()
+            .title("Custom Effects")
+            .description("Custom lighting effects managed by this application")
+            .build();
+
+        let rainbow_switch = adw::SwitchRow::builder()
+            .title("Rainbow Effect")
+            .subtitle("Cycle through all colors continuously")
+            .build();
+
+        let rainbow_speed_row = adw::ActionRow::builder()
+            .title("Speed")
+            .subtitle("How fast colors cycle")
+            .build();
+        let rainbow_speed_adjustment = gtk4::Adjustment::new(
+            settings.uint("rainbow-speed") as f64,
+            1.0,
+            10.0,
+            1.0,
+            1.0,
+            0.0,
+        );
+        let speed_scale = gtk4::Scale::builder()
+            .adjustment(&rainbow_speed_adjustment)
+            .draw_value(true)
+            .digits(0)
+            .hexpand(true)
+            .valign(gtk4::Align::Center)
+            .orientation(gtk4::Orientation::Horizontal)
+            .build();
+        speed_scale.set_size_request(150, -1);
+        rainbow_speed_row.add_suffix(&speed_scale);
+
+        custom_group.add(&rainbow_switch);
+        custom_group.add(&rainbow_speed_row);
+        self.append(&custom_group);
+
+        // Rainbow switch signal handler
+        {
+            let this = self.clone();
+            let mode_group_ref = mode_group.clone();
+            let color_group_ref = color_group.clone();
+            let speed_scale_ref = speed_scale.clone();
+            rainbow_switch.connect_active_notify(move |switch| {
+                if *this.imp().refreshing.borrow() {
+                    return;
+                }
+                if switch.is_active() {
+                    let speed = speed_scale_ref.value() as u32;
+                    if let Err(e) = backend::start_rainbow(speed) {
+                        eprintln!("Failed to start rainbow: {e}");
+                    }
+                    mode_group_ref.set_sensitive(false);
+                    color_group_ref.set_sensitive(false);
+                } else {
+                    if let Err(e) = backend::stop_rainbow() {
+                        eprintln!("Failed to stop rainbow: {e}");
+                    }
+                    mode_group_ref.set_sensitive(true);
+                    color_group_ref.set_sensitive(true);
+                }
+            });
+        }
+
+        // Speed scale: save to settings and restart if running
+        {
+            let settings_clone = settings;
+            let this = self.clone();
+            speed_scale.connect_value_changed(move |scale| {
+                if *this.imp().refreshing.borrow() {
+                    return;
+                }
+                let _ = settings_clone.set_uint("rainbow-speed", scale.value() as u32);
+                // Restart rainbow if currently running
+                if let Some(switch) = this.imp().rainbow_switch.borrow().as_ref() {
+                    if switch.is_active() {
+                        let speed = scale.value() as u32;
+                        if let Err(e) = backend::start_rainbow(speed) {
+                            eprintln!("Failed to restart rainbow: {e}");
+                        }
+                    }
+                }
+            });
+        }
+
         // Store references
         imp.mode_buttons.replace(mode_btns);
         imp.speed_buttons.replace(speed_btns);
@@ -421,6 +514,10 @@ impl AuraPage {
         imp.zone_dropdown.replace(Some(zone_dropdown));
         imp.color_row.replace(Some(color_row));
         imp.color2_row.replace(Some(color2_row));
+        imp.mode_group.replace(Some(mode_group));
+        imp.color_group.replace(Some(color_group));
+        imp.rainbow_switch.replace(Some(rainbow_switch));
+        imp.rainbow_speed_scale.replace(Some(speed_scale));
 
         // Set default mode and visibility
         mode_btns_first_active(&imp.mode_buttons.borrow());
@@ -593,6 +690,18 @@ impl AuraPage {
             Err(e) => {
                 eprintln!("Failed to get aura mode data: {e}");
             }
+        }
+
+        // Check rainbow status and update UI accordingly
+        let rainbow_running = backend::is_rainbow_running();
+        if let Some(switch) = imp.rainbow_switch.borrow().as_ref() {
+            switch.set_active(rainbow_running);
+        }
+        if let Some(group) = imp.mode_group.borrow().as_ref() {
+            group.set_sensitive(!rainbow_running);
+        }
+        if let Some(group) = imp.color_group.borrow().as_ref() {
+            group.set_sensitive(!rainbow_running);
         }
 
         *imp.refreshing.borrow_mut() = false;


### PR DESCRIPTION
## Summary
- Add custom rainbow effect that cycles through all colors continuously
- Speed slider (1-10) controls how fast colors cycle
- Effect runs as background process that survives app close
- Mode/color controls disabled while rainbow is active

## Limitations
- Rainbow effect must be stopped through the app
- External keyboard lighting control (asusctl CLI, other apps) won't work while rainbow is running

Closes #10

## Screenshot
<img width="1994" height="1454" alt="Screenshot From 2026-02-05 13-25-29" src="https://github.com/user-attachments/assets/2daab4a2-3c95-4059-b5e1-5cae2765da62" />