### PR TITLE
fix: use freeze_notify guards to prevent GTK state warnings

### DIFF
--- a/src/ui/pages/aura.rs
+++ b/src/ui/pages/aura.rs
@@ -1,5 +1,6 @@
 use adw::prelude::*;
 use gtk4::glib;
+use gtk4::glib::prelude::ObjectExt;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use libadwaita as adw;
@@ -617,6 +618,9 @@ impl AuraPage {
                     KeyboardBrightness::High => 3,
                 };
 
+                // Freeze all buttons to prevent GTK state accounting issues
+                // Guards auto-call thaw_notify when dropped
+                let _guards: Vec<_> = buttons.iter().map(|btn| btn.freeze_notify()).collect();
                 if let Some(btn) = buttons.get(index) {
                     btn.set_active(true);
                 }
@@ -630,38 +634,50 @@ impl AuraPage {
         match backend::get_aura_mode_data_dbus() {
             Ok(mode_data) => {
                 // Update mode buttons
-                let mode_buttons = imp.mode_buttons.borrow();
-                for (btn, mode) in mode_buttons.iter() {
-                    if *mode == mode_data.mode {
-                        btn.set_active(true);
-                        *imp.selected_mode.borrow_mut() = mode_data.mode;
-                        break;
+                {
+                    let mode_buttons = imp.mode_buttons.borrow();
+                    let _guards: Vec<_> =
+                        mode_buttons.iter().map(|(btn, _)| btn.freeze_notify()).collect();
+                    for (btn, mode) in mode_buttons.iter() {
+                        if *mode == mode_data.mode {
+                            btn.set_active(true);
+                            *imp.selected_mode.borrow_mut() = mode_data.mode;
+                            break;
+                        }
                     }
                 }
-                drop(mode_buttons);
 
                 // Update speed buttons
-                let speed_buttons = imp.speed_buttons.borrow();
-                for (btn, speed) in speed_buttons.iter() {
-                    if *speed == mode_data.speed {
-                        btn.set_active(true);
-                        break;
+                {
+                    let speed_buttons = imp.speed_buttons.borrow();
+                    let _guards: Vec<_> =
+                        speed_buttons.iter().map(|(btn, _)| btn.freeze_notify()).collect();
+                    for (btn, speed) in speed_buttons.iter() {
+                        if *speed == mode_data.speed {
+                            btn.set_active(true);
+                            break;
+                        }
                     }
                 }
-                drop(speed_buttons);
 
                 // Update direction buttons
-                let direction_buttons = imp.direction_buttons.borrow();
-                for (btn, dir) in direction_buttons.iter() {
-                    if *dir == mode_data.direction {
-                        btn.set_active(true);
-                        break;
+                {
+                    let direction_buttons = imp.direction_buttons.borrow();
+                    let _guards: Vec<_> = direction_buttons
+                        .iter()
+                        .map(|(btn, _)| btn.freeze_notify())
+                        .collect();
+                    for (btn, dir) in direction_buttons.iter() {
+                        if *dir == mode_data.direction {
+                            btn.set_active(true);
+                            break;
+                        }
                     }
                 }
-                drop(direction_buttons);
 
-                // Update primary color
+                // Update primary color (guard prevents callback during set_rgba)
                 if let Some(color_btn) = imp.color_button.borrow().as_ref() {
+                    let _guard = color_btn.freeze_notify();
                     let (r, g, b) = mode_data.color1;
                     let rgba = gtk4::gdk::RGBA::new(
                         r as f32 / 255.0,
@@ -674,6 +690,7 @@ impl AuraPage {
 
                 // Update secondary color
                 if let Some(color2_btn) = imp.color2_button.borrow().as_ref() {
+                    let _guard = color2_btn.freeze_notify();
                     let (r, g, b) = mode_data.color2;
                     let rgba = gtk4::gdk::RGBA::new(
                         r as f32 / 255.0,
@@ -695,6 +712,7 @@ impl AuraPage {
         // Check rainbow status and update UI accordingly
         let rainbow_running = backend::is_rainbow_running();
         if let Some(switch) = imp.rainbow_switch.borrow().as_ref() {
+            let _guard = switch.freeze_notify();
             switch.set_active(rainbow_running);
         }
         if let Some(group) = imp.mode_group.borrow().as_ref() {

--- a/src/ui/pages/power.rs
+++ b/src/ui/pages/power.rs
@@ -1,5 +1,6 @@
 use adw::prelude::*;
 use gtk4::glib;
+use gtk4::glib::prelude::ObjectExt;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use libadwaita as adw;
@@ -292,19 +293,27 @@ impl PowerPage {
         // Get current profile state via CLI (more reliable mapping)
         match backend::get_profile_state() {
             Ok(state) => {
-                let radios = imp.profile_radios.borrow();
-                let index = match state.active {
-                    PowerProfile::Quiet => 0,
-                    PowerProfile::Balanced => 1,
-                    PowerProfile::Performance => 2,
-                };
+                // Update profile radios
+                {
+                    let radios = imp.profile_radios.borrow();
+                    let index = match state.active {
+                        PowerProfile::Quiet => 0,
+                        PowerProfile::Balanced => 1,
+                        PowerProfile::Performance => 2,
+                    };
 
-                if let Some(radio) = radios.get(index) {
-                    radio.set_active(true);
+                    // Freeze all radios to prevent GTK state accounting issues
+                    // Guards auto-call thaw_notify when dropped
+                    let _guards: Vec<_> =
+                        radios.iter().map(|radio| radio.freeze_notify()).collect();
+                    if let Some(radio) = radios.get(index) {
+                        radio.set_active(true);
+                    }
                 }
 
                 // Set AC combo
                 if let Some(combo) = imp.ac_combo.borrow().as_ref() {
+                    let _guard = combo.freeze_notify();
                     let ac_index = match state.on_ac {
                         PowerProfile::Quiet => 0,
                         PowerProfile::Balanced => 1,
@@ -315,6 +324,7 @@ impl PowerPage {
 
                 // Set battery combo
                 if let Some(combo) = imp.battery_combo.borrow().as_ref() {
+                    let _guard = combo.freeze_notify();
                     let bat_index = match state.on_battery {
                         PowerProfile::Quiet => 0,
                         PowerProfile::Balanced => 1,
@@ -333,6 +343,7 @@ impl PowerPage {
             if let Some(scale) = imp.charge_scale.borrow().as_ref() {
                 match backend::get_charge_limit_dbus() {
                     Ok(limit) => {
+                        let _guard = scale.freeze_notify();
                         scale.set_value(limit as f64);
                     }
                     Err(e) => {

--- a/src/ui/pages/slash.rs
+++ b/src/ui/pages/slash.rs
@@ -1,5 +1,6 @@
 use adw::prelude::*;
 use gtk4::glib;
+use gtk4::glib::prelude::ObjectExt;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use libadwaita as adw;
@@ -390,6 +391,7 @@ impl SlashPage {
         let slash_enabled = if let Some(switch) = imp.enable_switch.borrow().as_ref() {
             match backend::get_slash_enabled() {
                 Ok(enabled) => {
+                    let _guard = switch.freeze_notify();
                     switch.set_active(enabled);
                     enabled
                 }
@@ -407,6 +409,7 @@ impl SlashPage {
             scale.set_sensitive(slash_enabled);
             match backend::get_slash_brightness() {
                 Ok(brightness) => {
+                    let _guard = scale.freeze_notify();
                     scale.set_value(brightness as f64);
                 }
                 Err(e) => {
@@ -437,6 +440,7 @@ impl SlashPage {
                         SlashMode::Start => 14,
                         SlashMode::Buzzer => 15,
                     };
+                    let _guard = combo.freeze_notify();
                     combo.set_selected(index);
                 }
                 Err(e) => {
@@ -449,6 +453,7 @@ impl SlashPage {
         if let Some(combo) = imp.interval_combo.borrow().as_ref() {
             match backend::get_slash_interval() {
                 Ok(interval) => {
+                    let _guard = combo.freeze_notify();
                     combo.set_selected(interval as u32);
                 }
                 Err(e) => {
@@ -460,30 +465,35 @@ impl SlashPage {
         // Load show-on states from D-Bus
         if let Some(switch) = imp.show_on_boot.borrow().as_ref() {
             if let Ok(value) = backend::get_slash_show_on_boot() {
+                let _guard = switch.freeze_notify();
                 switch.set_active(value);
             }
         }
 
         if let Some(switch) = imp.show_on_shutdown.borrow().as_ref() {
             if let Ok(value) = backend::get_slash_show_on_shutdown() {
+                let _guard = switch.freeze_notify();
                 switch.set_active(value);
             }
         }
 
         if let Some(switch) = imp.show_on_sleep.borrow().as_ref() {
             if let Ok(value) = backend::get_slash_show_on_sleep() {
+                let _guard = switch.freeze_notify();
                 switch.set_active(value);
             }
         }
 
         if let Some(switch) = imp.show_on_battery.borrow().as_ref() {
             if let Ok(value) = backend::get_slash_show_on_battery() {
+                let _guard = switch.freeze_notify();
                 switch.set_active(value);
             }
         }
 
         if let Some(switch) = imp.show_battery_warning.borrow().as_ref() {
             if let Ok(value) = backend::get_slash_show_battery_warning() {
+                let _guard = switch.freeze_notify();
                 switch.set_active(value);
             }
         }


### PR DESCRIPTION
## Summary
- Use `freeze_notify()` RAII guards during programmatic widget updates in refresh_data()
- Prevents "Broken accounting of active state" GTK warnings
- Applied to AuraPage, PowerPage, and SlashPage

## Test plan
- [x] Run the app and navigate between pages
- [x] Verify no GTK warnings appear in terminal output