### PR TITLE
test: add comprehensive backend unit tests

### DIFF
--- a/src/backend/aura.rs
+++ b/src/backend/aura.rs
@@ -302,4 +302,131 @@ mod tests {
             Ok(KeyboardBrightness::Off)
         ));
     }
+
+    // ------------------------------------------------------------------------
+    // hsv_to_hex Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_hsv_to_hex_primary_colors() {
+        // Red: H=0, S=1, V=1
+        assert_eq!(hsv_to_hex(0.0, 1.0, 1.0), "ff0000");
+
+        // Green: H=120, S=1, V=1
+        assert_eq!(hsv_to_hex(120.0, 1.0, 1.0), "00ff00");
+
+        // Blue: H=240, S=1, V=1
+        assert_eq!(hsv_to_hex(240.0, 1.0, 1.0), "0000ff");
+    }
+
+    #[test]
+    fn test_hsv_to_hex_secondary_colors() {
+        // Yellow: H=60, S=1, V=1
+        assert_eq!(hsv_to_hex(60.0, 1.0, 1.0), "ffff00");
+
+        // Cyan: H=180, S=1, V=1
+        assert_eq!(hsv_to_hex(180.0, 1.0, 1.0), "00ffff");
+
+        // Magenta: H=300, S=1, V=1
+        assert_eq!(hsv_to_hex(300.0, 1.0, 1.0), "ff00ff");
+    }
+
+    #[test]
+    fn test_hsv_to_hex_white_and_black() {
+        // White: S=0, V=1 (hue doesn't matter)
+        assert_eq!(hsv_to_hex(0.0, 0.0, 1.0), "ffffff");
+
+        // Black: V=0 (hue and saturation don't matter)
+        assert_eq!(hsv_to_hex(0.0, 1.0, 0.0), "000000");
+        assert_eq!(hsv_to_hex(180.0, 0.5, 0.0), "000000");
+    }
+
+    #[test]
+    fn test_hsv_to_hex_grayscale() {
+        // 50% gray: S=0, V=0.5
+        assert_eq!(hsv_to_hex(0.0, 0.0, 0.5), "7f7f7f");
+
+        // 25% gray
+        assert_eq!(hsv_to_hex(0.0, 0.0, 0.25), "3f3f3f");
+    }
+
+    #[test]
+    fn test_hsv_to_hex_desaturated_colors() {
+        // Light red (pink-ish): H=0, S=0.5, V=1
+        assert_eq!(hsv_to_hex(0.0, 0.5, 1.0), "ff7f7f");
+
+        // Light green: H=120, S=0.5, V=1
+        assert_eq!(hsv_to_hex(120.0, 0.5, 1.0), "7fff7f");
+    }
+
+    #[test]
+    fn test_hsv_to_hex_darkened_colors() {
+        // Dark red: H=0, S=1, V=0.5
+        assert_eq!(hsv_to_hex(0.0, 1.0, 0.5), "7f0000");
+
+        // Dark blue: H=240, S=1, V=0.5
+        assert_eq!(hsv_to_hex(240.0, 1.0, 0.5), "00007f");
+    }
+
+    #[test]
+    fn test_hsv_to_hex_intermediate_hues() {
+        // Orange: H=30
+        assert_eq!(hsv_to_hex(30.0, 1.0, 1.0), "ff7f00");
+
+        // Lime: H=90
+        assert_eq!(hsv_to_hex(90.0, 1.0, 1.0), "7fff00");
+
+        // Spring green: H=150
+        assert_eq!(hsv_to_hex(150.0, 1.0, 1.0), "00ff7f");
+
+        // Azure: H=210
+        assert_eq!(hsv_to_hex(210.0, 1.0, 1.0), "007fff");
+
+        // Violet: H=270
+        assert_eq!(hsv_to_hex(270.0, 1.0, 1.0), "7f00ff");
+
+        // Rose: H=330
+        assert_eq!(hsv_to_hex(330.0, 1.0, 1.0), "ff007f");
+    }
+
+    #[test]
+    fn test_hsv_to_hex_edge_cases() {
+        // Hue at 360 should be same as 0 (red)
+        // Note: Due to modulo operation, h=360 behaves like h=0
+        assert_eq!(hsv_to_hex(360.0, 1.0, 1.0), "ff0000");
+
+        // Just before 60 degrees
+        let result = hsv_to_hex(59.9, 1.0, 1.0);
+        assert!(result.starts_with("ff")); // Should be mostly yellow
+    }
+
+    // ------------------------------------------------------------------------
+    // Rainbow Effect Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_rainbow_pid_path_format() {
+        let path = rainbow_pid_path();
+        let path_str = path.to_string_lossy();
+
+        // Should end with the expected file name
+        assert!(path_str.ends_with("asusctl-gui/rainbow.pid"));
+    }
+
+    #[test]
+    fn test_rainbow_delay_calculation() {
+        // Test the delay formula: 0.5 / speed^3.7
+        // Speed 1: delay = 0.5 / 1 = 0.5
+        let delay_1 = 0.5 / (1u32 as f64).powf(3.7);
+        assert!((delay_1 - 0.5).abs() < 0.001);
+
+        // Speed 2: delay = 0.5 / 2^3.7 ≈ 0.038
+        let delay_2 = 0.5 / (2u32 as f64).powf(3.7);
+        assert!(delay_2 < delay_1);
+        assert!(delay_2 > 0.0);
+
+        // Speed 3: delay should be even smaller
+        let delay_3 = 0.5 / (3u32 as f64).powf(3.7);
+        assert!(delay_3 < delay_2);
+    }
 }

--- a/src/backend/error.rs
+++ b/src/backend/error.rs
@@ -28,3 +28,81 @@ impl std::error::Error for AsusctlError {}
 
 /// Result type alias for asusctl operations.
 pub type Result<T> = std::result::Result<T, AsusctlError>;
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display_not_installed() {
+        let err = AsusctlError::NotInstalled;
+        assert_eq!(err.to_string(), "asusctl is not installed");
+    }
+
+    #[test]
+    fn test_error_display_service_not_running() {
+        let err = AsusctlError::ServiceNotRunning;
+        assert_eq!(err.to_string(), "asusd service is not running");
+    }
+
+    #[test]
+    fn test_error_display_command_failed() {
+        let err = AsusctlError::CommandFailed("exit code 1".to_string());
+        assert_eq!(err.to_string(), "Command failed: exit code 1");
+
+        let err2 = AsusctlError::CommandFailed("permission denied".to_string());
+        assert_eq!(err2.to_string(), "Command failed: permission denied");
+    }
+
+    #[test]
+    fn test_error_display_parse_error() {
+        let err = AsusctlError::ParseError("invalid format".to_string());
+        assert_eq!(err.to_string(), "Parse error: invalid format");
+
+        let err2 = AsusctlError::ParseError("unexpected EOF".to_string());
+        assert_eq!(err2.to_string(), "Parse error: unexpected EOF");
+    }
+
+    #[test]
+    fn test_error_debug() {
+        let err = AsusctlError::NotInstalled;
+        let debug_str = format!("{:?}", err);
+        assert_eq!(debug_str, "NotInstalled");
+
+        let err2 = AsusctlError::CommandFailed("test".to_string());
+        let debug_str2 = format!("{:?}", err2);
+        assert!(debug_str2.contains("CommandFailed"));
+        assert!(debug_str2.contains("test"));
+    }
+
+    #[test]
+    fn test_error_clone() {
+        let err = AsusctlError::CommandFailed("original".to_string());
+        let cloned = err.clone();
+        assert_eq!(err.to_string(), cloned.to_string());
+    }
+
+    #[test]
+    fn test_result_type_alias() {
+        fn test_ok() -> Result<i32> {
+            Ok(42)
+        }
+
+        fn test_err() -> Result<i32> {
+            Err(AsusctlError::NotInstalled)
+        }
+
+        assert_eq!(test_ok().unwrap(), 42);
+        assert!(test_err().is_err());
+    }
+
+    #[test]
+    fn test_error_is_std_error() {
+        let err: Box<dyn std::error::Error> = Box::new(AsusctlError::NotInstalled);
+        assert_eq!(err.to_string(), "asusctl is not installed");
+    }
+}

--- a/src/backend/power.rs
+++ b/src/backend/power.rs
@@ -150,6 +150,10 @@ fn parse_profile_state(output: &str) -> Result<ProfileState> {
 mod tests {
     use super::*;
 
+    // ------------------------------------------------------------------------
+    // parse_profile_state Tests
+    // ------------------------------------------------------------------------
+
     #[test]
     fn test_parse_profile_state() {
         // Test actual asusctl output format
@@ -180,5 +184,126 @@ Profile on Battery is Quiet"#;
         assert_eq!(state.active, PowerProfile::Quiet);
         assert_eq!(state.on_ac, PowerProfile::Quiet);
         assert_eq!(state.on_battery, PowerProfile::Quiet);
+    }
+
+    #[test]
+    fn test_parse_profile_state_balanced() {
+        let output = r#"Active profile: Balanced
+
+AC profile Balanced
+Battery profile Quiet"#;
+
+        let state = parse_profile_state(output).unwrap();
+        assert_eq!(state.active, PowerProfile::Balanced);
+        assert_eq!(state.on_ac, PowerProfile::Balanced);
+        assert_eq!(state.on_battery, PowerProfile::Quiet);
+    }
+
+    #[test]
+    fn test_parse_profile_state_performance() {
+        let output = r#"Active profile: Performance
+
+AC profile Performance
+Battery profile Balanced"#;
+
+        let state = parse_profile_state(output).unwrap();
+        assert_eq!(state.active, PowerProfile::Performance);
+        assert_eq!(state.on_ac, PowerProfile::Performance);
+        assert_eq!(state.on_battery, PowerProfile::Balanced);
+    }
+
+    #[test]
+    fn test_parse_profile_state_mixed_profiles() {
+        let output = r#"Active profile: Quiet
+
+AC profile Performance
+Battery profile Quiet"#;
+
+        let state = parse_profile_state(output).unwrap();
+        assert_eq!(state.active, PowerProfile::Quiet);
+        assert_eq!(state.on_ac, PowerProfile::Performance);
+        assert_eq!(state.on_battery, PowerProfile::Quiet);
+    }
+
+    #[test]
+    fn test_parse_profile_state_empty_output() {
+        let output = "";
+        let state = parse_profile_state(output).unwrap();
+        // Should return defaults
+        assert_eq!(state.active, PowerProfile::default());
+        assert_eq!(state.on_ac, PowerProfile::default());
+        assert_eq!(state.on_battery, PowerProfile::default());
+    }
+
+    #[test]
+    fn test_parse_profile_state_partial_output() {
+        let output = "Active profile: Performance";
+        let state = parse_profile_state(output).unwrap();
+        assert_eq!(state.active, PowerProfile::Performance);
+        // AC and battery should be defaults
+        assert_eq!(state.on_ac, PowerProfile::default());
+        assert_eq!(state.on_battery, PowerProfile::default());
+    }
+
+    #[test]
+    fn test_parse_profile_state_with_extra_whitespace() {
+        let output = r#"  Active profile:   Quiet
+
+  AC profile   Balanced
+  Battery profile   Performance  "#;
+
+        let state = parse_profile_state(output).unwrap();
+        assert_eq!(state.active, PowerProfile::Quiet);
+        assert_eq!(state.on_ac, PowerProfile::Balanced);
+        assert_eq!(state.on_battery, PowerProfile::Performance);
+    }
+
+    #[test]
+    fn test_parse_profile_state_case_insensitive() {
+        let output = r#"Active profile: QUIET
+
+AC profile BALANCED
+Battery profile PERFORMANCE"#;
+
+        let state = parse_profile_state(output).unwrap();
+        assert_eq!(state.active, PowerProfile::Quiet);
+        assert_eq!(state.on_ac, PowerProfile::Balanced);
+        assert_eq!(state.on_battery, PowerProfile::Performance);
+    }
+
+    // ------------------------------------------------------------------------
+    // PowerProfile mapping for powerprofilesctl Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_power_profile_ppdctl_mapping() {
+        // Test that the mapping in set_profile_ppdctl is correct
+        // These are the expected mappings to power-profiles-daemon names
+        assert_eq!(
+            match PowerProfile::Quiet {
+                PowerProfile::Quiet => "power-saver",
+                PowerProfile::Balanced => "balanced",
+                PowerProfile::Performance => "performance",
+            },
+            "power-saver"
+        );
+
+        assert_eq!(
+            match PowerProfile::Balanced {
+                PowerProfile::Quiet => "power-saver",
+                PowerProfile::Balanced => "balanced",
+                PowerProfile::Performance => "performance",
+            },
+            "balanced"
+        );
+
+        assert_eq!(
+            match PowerProfile::Performance {
+                PowerProfile::Quiet => "power-saver",
+                PowerProfile::Balanced => "balanced",
+                PowerProfile::Performance => "performance",
+            },
+            "performance"
+        );
     }
 }

--- a/src/backend/slash.rs
+++ b/src/backend/slash.rs
@@ -249,3 +249,229 @@ fn extract_string_value(line: &str) -> Option<String> {
             .to_string(),
     )
 }
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------------
+    // extract_number Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_extract_number_valid() {
+        assert_eq!(extract_number("brightness: 255,"), Some(255));
+        assert_eq!(extract_number("brightness: 128,"), Some(128));
+        assert_eq!(extract_number("display_interval: 5,"), Some(5));
+        assert_eq!(extract_number("value: 0,"), Some(0));
+    }
+
+    #[test]
+    fn test_extract_number_without_trailing_comma() {
+        assert_eq!(extract_number("brightness: 255"), Some(255));
+        assert_eq!(extract_number("interval: 3"), Some(3));
+    }
+
+    #[test]
+    fn test_extract_number_with_whitespace() {
+        // Leading whitespace after colon is handled
+        assert_eq!(extract_number("brightness:   255,"), Some(255));
+        // Note: "brightness: 255  ," won't parse because whitespace before comma
+        // is not trimmed by the simple parsing logic. This matches expected config format.
+        assert_eq!(extract_number("  brightness: 100,"), Some(100));
+    }
+
+    #[test]
+    fn test_extract_number_invalid() {
+        assert_eq!(extract_number("brightness: abc,"), None);
+        assert_eq!(extract_number("no_colon_here"), None);
+        assert_eq!(extract_number("brightness:"), None);
+        assert_eq!(extract_number(""), None);
+    }
+
+    #[test]
+    fn test_extract_number_large_values() {
+        assert_eq!(extract_number("value: 4294967295,"), Some(4294967295));
+    }
+
+    // ------------------------------------------------------------------------
+    // extract_string_value Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_extract_string_value_valid() {
+        assert_eq!(
+            extract_string_value("display_mode: BitStream,"),
+            Some("BitStream".to_string())
+        );
+        assert_eq!(
+            extract_string_value("display_mode: Flow,"),
+            Some("Flow".to_string())
+        );
+        assert_eq!(
+            extract_string_value("mode: Static,"),
+            Some("Static".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_string_value_without_trailing_comma() {
+        assert_eq!(
+            extract_string_value("display_mode: Spectrum"),
+            Some("Spectrum".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_string_value_with_whitespace() {
+        assert_eq!(
+            extract_string_value("display_mode:   BitStream,"),
+            Some("BitStream".to_string())
+        );
+        assert_eq!(
+            extract_string_value("  display_mode: Flow,  "),
+            Some("Flow".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_string_value_empty_value() {
+        assert_eq!(extract_string_value("mode:,"), Some("".to_string()));
+        assert_eq!(extract_string_value("mode: ,"), Some("".to_string()));
+    }
+
+    #[test]
+    fn test_extract_string_value_no_colon() {
+        assert_eq!(extract_string_value("no_colon_here"), None);
+        assert_eq!(extract_string_value(""), None);
+    }
+
+    // ------------------------------------------------------------------------
+    // Parsing enabled line Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_enabled_line() {
+        // Test parsing enabled: true/false from config lines
+        assert!("enabled: true,".contains("true"));
+        assert!(!"enabled: false,".contains("true"));
+    }
+
+    // ------------------------------------------------------------------------
+    // SlashState Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_slash_state_default_values() {
+        let state = SlashState::default();
+        assert!(!state.enabled);
+        assert_eq!(state.brightness, 0);
+        assert_eq!(state.interval, 0);
+        assert_eq!(state.mode, SlashMode::Flow);
+    }
+
+    #[test]
+    fn test_slash_state_custom_values() {
+        let state = SlashState {
+            enabled: true,
+            brightness: 200,
+            interval: 3,
+            mode: SlashMode::BitStream,
+        };
+        assert!(state.enabled);
+        assert_eq!(state.brightness, 200);
+        assert_eq!(state.interval, 3);
+        assert_eq!(state.mode, SlashMode::BitStream);
+    }
+
+    // ------------------------------------------------------------------------
+    // Integration-style parsing Tests (simulated config content)
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_config_lines() {
+        // Simulate parsing a config file line by line
+        let config_content = r#"(
+    enabled: true,
+    brightness: 180,
+    display_interval: 2,
+    display_mode: Spectrum,
+)"#;
+
+        let mut state = SlashState::default();
+
+        for line in config_content.lines() {
+            let line = line.trim();
+
+            if line.starts_with("enabled:") {
+                state.enabled = line.contains("true");
+            } else if line.starts_with("brightness:") {
+                if let Some(val) = extract_number(line) {
+                    state.brightness = val as u8;
+                }
+            } else if line.starts_with("display_interval:") {
+                if let Some(val) = extract_number(line) {
+                    state.interval = val as u8;
+                }
+            } else if line.starts_with("display_mode:") {
+                if let Some(mode_str) = extract_string_value(line) {
+                    state.mode = SlashMode::from_str(&mode_str).unwrap_or_default();
+                }
+            }
+        }
+
+        assert!(state.enabled);
+        assert_eq!(state.brightness, 180);
+        assert_eq!(state.interval, 2);
+        assert_eq!(state.mode, SlashMode::Spectrum);
+    }
+
+    #[test]
+    fn test_parse_config_lines_disabled() {
+        let config_content = r#"(
+    enabled: false,
+    brightness: 100,
+    display_interval: 5,
+    display_mode: Hazard,
+)"#;
+
+        let mut state = SlashState::default();
+
+        for line in config_content.lines() {
+            let line = line.trim();
+
+            if line.starts_with("enabled:") {
+                state.enabled = line.contains("true");
+            } else if line.starts_with("brightness:") {
+                if let Some(val) = extract_number(line) {
+                    state.brightness = val as u8;
+                }
+            } else if line.starts_with("display_interval:") {
+                if let Some(val) = extract_number(line) {
+                    state.interval = val as u8;
+                }
+            } else if line.starts_with("display_mode:") {
+                if let Some(mode_str) = extract_string_value(line) {
+                    state.mode = SlashMode::from_str(&mode_str).unwrap_or_default();
+                }
+            }
+        }
+
+        assert!(!state.enabled);
+        assert_eq!(state.brightness, 100);
+        assert_eq!(state.interval, 5);
+        assert_eq!(state.mode, SlashMode::Hazard);
+    }
+
+    #[test]
+    fn test_parse_config_with_unknown_mode_falls_back_to_default() {
+        let line = "display_mode: UnknownMode,";
+        let mode_str = extract_string_value(line).unwrap();
+        let mode = SlashMode::from_str(&mode_str).unwrap_or_default();
+        assert_eq!(mode, SlashMode::Flow); // Default mode
+    }
+}

--- a/src/backend/system.rs
+++ b/src/backend/system.rs
@@ -223,6 +223,10 @@ fn extract_section(output: &str, header: &str) -> String {
 mod tests {
     use super::*;
 
+    // ------------------------------------------------------------------------
+    // parse_system_info Tests
+    // ------------------------------------------------------------------------
+
     #[test]
     fn test_parse_system_info() {
         let output = r#"Starting version 6.2.0
@@ -237,5 +241,234 @@ asusctl version: 6.2.0
         assert_eq!(info.asusctl_version, "6.2.0");
         assert_eq!(info.product_family, "ROG Zephyrus G14");
         assert_eq!(info.board_name, "GA403UV");
+    }
+
+    #[test]
+    fn test_parse_system_info_software_version_format() {
+        let output = r#"Software version: 6.1.0
+Product family: ROG Flow X13
+Board name: GV302XA"#;
+
+        let info = parse_system_info(output).unwrap();
+        assert_eq!(info.asusctl_version, "6.1.0");
+        assert_eq!(info.product_family, "ROG Flow X13");
+        assert_eq!(info.board_name, "GV302XA");
+    }
+
+    #[test]
+    fn test_parse_system_info_empty_output() {
+        let output = "";
+        let info = parse_system_info(output).unwrap();
+        assert!(info.asusctl_version.is_empty());
+        assert!(info.product_family.is_empty());
+        assert!(info.board_name.is_empty());
+    }
+
+    #[test]
+    fn test_parse_system_info_partial_output() {
+        let output = "asusctl version: 6.2.0";
+        let info = parse_system_info(output).unwrap();
+        assert_eq!(info.asusctl_version, "6.2.0");
+        assert!(info.product_family.is_empty());
+        assert!(info.board_name.is_empty());
+    }
+
+    // ------------------------------------------------------------------------
+    // extract_section Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_extract_section_simple() {
+        let output = r#"Some header info
+Supported Keyboard Brightness:
+[
+    Off,
+    Low,
+    Med,
+    High,
+]
+Other section:"#;
+
+        let section = extract_section(output, "Supported Keyboard Brightness:");
+        assert!(section.contains("Off"));
+        assert!(section.contains("Low"));
+        assert!(section.contains("Med"));
+        assert!(section.contains("High"));
+    }
+
+    #[test]
+    fn test_extract_section_not_found() {
+        let output = "Some content without the header";
+        let section = extract_section(output, "Nonexistent Header:");
+        assert!(section.is_empty());
+    }
+
+    #[test]
+    fn test_extract_section_with_aura_modes() {
+        let output = r#"Supported Aura Modes:
+[
+    Static,
+    Breathe,
+    RainbowCycle,
+    Stars,
+]
+Next section:"#;
+
+        let section = extract_section(output, "Supported Aura Modes:");
+        assert!(section.contains("Static"));
+        assert!(section.contains("Breathe"));
+        assert!(section.contains("RainbowCycle"));
+        assert!(section.contains("Stars"));
+    }
+
+    // ------------------------------------------------------------------------
+    // parse_supported_features Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_supported_features_full() {
+        let output = r#"Core functions:
+  xyz.ljones.Aura
+  xyz.ljones.Platform
+  xyz.ljones.FanCurves
+  xyz.ljones.Slash
+
+Platform properties:
+  ChargeControlEndThreshold
+  ThrottlePolicy
+
+Supported Keyboard Brightness:
+[
+    Off,
+    Low,
+    Med,
+    High,
+]
+
+Supported Aura Modes:
+[
+    Static,
+    Breathe,
+    RainbowCycle,
+    RainbowWave,
+    Stars,
+    Rain,
+]
+
+Supported Aura Zones:
+[
+    Key1,
+    Key2,
+]
+"#;
+
+        let features = parse_supported_features(output).unwrap();
+
+        // Core functions
+        assert!(features.has_aura);
+        assert!(features.has_platform);
+        assert!(features.has_fan_curves);
+        assert!(features.has_slash);
+
+        // Platform properties
+        assert!(features.has_charge_control);
+        assert!(features.has_throttle_policy);
+
+        // Keyboard brightness
+        assert_eq!(features.keyboard_brightness_levels.len(), 4);
+        assert!(features
+            .keyboard_brightness_levels
+            .contains(&KeyboardBrightness::Off));
+        assert!(features
+            .keyboard_brightness_levels
+            .contains(&KeyboardBrightness::High));
+
+        // Aura modes
+        assert!(features.aura_modes.len() >= 6);
+        assert!(features.aura_modes.contains(&AuraMode::Static));
+        assert!(features.aura_modes.contains(&AuraMode::Breathe));
+        assert!(features.aura_modes.contains(&AuraMode::RainbowCycle));
+        assert!(features.aura_modes.contains(&AuraMode::RainbowWave));
+        assert!(features.aura_modes.contains(&AuraMode::Stars));
+        assert!(features.aura_modes.contains(&AuraMode::Rain));
+
+        // Aura zones
+        assert_eq!(features.aura_zones.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_supported_features_minimal() {
+        let output = "xyz.ljones.Aura";
+        let features = parse_supported_features(output).unwrap();
+        assert!(features.has_aura);
+        assert!(!features.has_platform);
+        assert!(!features.has_slash);
+    }
+
+    #[test]
+    fn test_parse_supported_features_no_aura() {
+        let output = r#"Core functions:
+  xyz.ljones.Platform
+  xyz.ljones.Slash
+"#;
+        let features = parse_supported_features(output).unwrap();
+        assert!(!features.has_aura);
+        assert!(features.has_platform);
+        assert!(features.has_slash);
+    }
+
+    #[test]
+    fn test_parse_supported_features_empty() {
+        let output = "";
+        let features = parse_supported_features(output).unwrap();
+        assert!(!features.has_aura);
+        assert!(!features.has_platform);
+        assert!(!features.has_slash);
+        assert!(features.keyboard_brightness_levels.is_empty());
+        assert!(features.aura_modes.is_empty());
+    }
+
+    #[test]
+    fn test_parse_supported_features_all_aura_modes() {
+        let output = r#"Supported Aura Modes:
+[
+    Static,
+    Breathe,
+    RainbowCycle,
+    RainbowWave,
+    Stars,
+    Rain,
+    Highlight,
+    Laser,
+    Ripple,
+    Pulse,
+    Comet,
+    Flash,
+]
+"#;
+
+        let features = parse_supported_features(output).unwrap();
+        assert_eq!(features.aura_modes.len(), 12);
+    }
+
+    #[test]
+    fn test_parse_supported_features_no_duplicate_modes() {
+        // Test that modes are not duplicated if they appear multiple times
+        let output = r#"Supported Aura Modes:
+[
+    Static,
+    Static,
+    Breathe,
+]
+"#;
+
+        let features = parse_supported_features(output).unwrap();
+        // Should only have 2 unique modes
+        let static_count = features
+            .aura_modes
+            .iter()
+            .filter(|m| **m == AuraMode::Static)
+            .count();
+        assert_eq!(static_count, 1);
     }
 }

--- a/src/backend/types.rs
+++ b/src/backend/types.rs
@@ -457,3 +457,522 @@ pub struct SystemInfo {
     pub product_family: String,
     pub board_name: String,
 }
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------------
+    // KeyboardBrightness Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_keyboard_brightness_from_str_valid() {
+        assert_eq!(
+            KeyboardBrightness::from_str("off").unwrap(),
+            KeyboardBrightness::Off
+        );
+        assert_eq!(
+            KeyboardBrightness::from_str("OFF").unwrap(),
+            KeyboardBrightness::Off
+        );
+        assert_eq!(
+            KeyboardBrightness::from_str("low").unwrap(),
+            KeyboardBrightness::Low
+        );
+        assert_eq!(
+            KeyboardBrightness::from_str("Low").unwrap(),
+            KeyboardBrightness::Low
+        );
+        assert_eq!(
+            KeyboardBrightness::from_str("med").unwrap(),
+            KeyboardBrightness::Med
+        );
+        assert_eq!(
+            KeyboardBrightness::from_str("MED").unwrap(),
+            KeyboardBrightness::Med
+        );
+        assert_eq!(
+            KeyboardBrightness::from_str("high").unwrap(),
+            KeyboardBrightness::High
+        );
+        assert_eq!(
+            KeyboardBrightness::from_str("HIGH").unwrap(),
+            KeyboardBrightness::High
+        );
+    }
+
+    #[test]
+    fn test_keyboard_brightness_from_str_invalid() {
+        assert!(KeyboardBrightness::from_str("invalid").is_err());
+        assert!(KeyboardBrightness::from_str("").is_err());
+        assert!(KeyboardBrightness::from_str("medium").is_err());
+    }
+
+    #[test]
+    fn test_keyboard_brightness_display() {
+        assert_eq!(KeyboardBrightness::Off.to_string(), "off");
+        assert_eq!(KeyboardBrightness::Low.to_string(), "low");
+        assert_eq!(KeyboardBrightness::Med.to_string(), "med");
+        assert_eq!(KeyboardBrightness::High.to_string(), "high");
+    }
+
+    #[test]
+    fn test_keyboard_brightness_default() {
+        assert_eq!(KeyboardBrightness::default(), KeyboardBrightness::High);
+    }
+
+    // ------------------------------------------------------------------------
+    // PowerProfile Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_power_profile_from_str_valid() {
+        assert_eq!(
+            PowerProfile::from_str("quiet").unwrap(),
+            PowerProfile::Quiet
+        );
+        assert_eq!(
+            PowerProfile::from_str("QUIET").unwrap(),
+            PowerProfile::Quiet
+        );
+        assert_eq!(
+            PowerProfile::from_str("balanced").unwrap(),
+            PowerProfile::Balanced
+        );
+        assert_eq!(
+            PowerProfile::from_str("Balanced").unwrap(),
+            PowerProfile::Balanced
+        );
+        assert_eq!(
+            PowerProfile::from_str("performance").unwrap(),
+            PowerProfile::Performance
+        );
+        assert_eq!(
+            PowerProfile::from_str("PERFORMANCE").unwrap(),
+            PowerProfile::Performance
+        );
+    }
+
+    #[test]
+    fn test_power_profile_from_str_invalid() {
+        assert!(PowerProfile::from_str("turbo").is_err());
+        assert!(PowerProfile::from_str("").is_err());
+        assert!(PowerProfile::from_str("power-saver").is_err());
+    }
+
+    #[test]
+    fn test_power_profile_display() {
+        assert_eq!(PowerProfile::Quiet.to_string(), "Quiet");
+        assert_eq!(PowerProfile::Balanced.to_string(), "Balanced");
+        assert_eq!(PowerProfile::Performance.to_string(), "Performance");
+    }
+
+    #[test]
+    fn test_power_profile_default() {
+        assert_eq!(PowerProfile::default(), PowerProfile::Balanced);
+    }
+
+    // ------------------------------------------------------------------------
+    // AuraMode Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_aura_mode_from_str_valid() {
+        assert_eq!(AuraMode::from_str("static").unwrap(), AuraMode::Static);
+        assert_eq!(AuraMode::from_str("Static").unwrap(), AuraMode::Static);
+        assert_eq!(AuraMode::from_str("breathe").unwrap(), AuraMode::Breathe);
+        assert_eq!(AuraMode::from_str("stars").unwrap(), AuraMode::Stars);
+        assert_eq!(AuraMode::from_str("rain").unwrap(), AuraMode::Rain);
+        assert_eq!(
+            AuraMode::from_str("highlight").unwrap(),
+            AuraMode::Highlight
+        );
+        assert_eq!(AuraMode::from_str("laser").unwrap(), AuraMode::Laser);
+        assert_eq!(AuraMode::from_str("ripple").unwrap(), AuraMode::Ripple);
+        assert_eq!(AuraMode::from_str("pulse").unwrap(), AuraMode::Pulse);
+        assert_eq!(AuraMode::from_str("comet").unwrap(), AuraMode::Comet);
+        assert_eq!(AuraMode::from_str("flash").unwrap(), AuraMode::Flash);
+    }
+
+    #[test]
+    fn test_aura_mode_from_str_rainbow_variants() {
+        // Test all accepted formats for rainbow modes
+        assert_eq!(
+            AuraMode::from_str("rainbow-cycle").unwrap(),
+            AuraMode::RainbowCycle
+        );
+        assert_eq!(
+            AuraMode::from_str("rainbowcycle").unwrap(),
+            AuraMode::RainbowCycle
+        );
+        assert_eq!(
+            AuraMode::from_str("rainbow cycle").unwrap(),
+            AuraMode::RainbowCycle
+        );
+        assert_eq!(
+            AuraMode::from_str("rainbow-wave").unwrap(),
+            AuraMode::RainbowWave
+        );
+        assert_eq!(
+            AuraMode::from_str("rainbowwave").unwrap(),
+            AuraMode::RainbowWave
+        );
+        assert_eq!(
+            AuraMode::from_str("rainbow wave").unwrap(),
+            AuraMode::RainbowWave
+        );
+    }
+
+    #[test]
+    fn test_aura_mode_from_str_invalid() {
+        assert!(AuraMode::from_str("invalid").is_err());
+        assert!(AuraMode::from_str("").is_err());
+        assert!(AuraMode::from_str("strobe").is_err());
+    }
+
+    #[test]
+    fn test_aura_mode_cli_name() {
+        assert_eq!(AuraMode::Static.cli_name(), "static");
+        assert_eq!(AuraMode::Breathe.cli_name(), "breathe");
+        assert_eq!(AuraMode::RainbowCycle.cli_name(), "rainbow-cycle");
+        assert_eq!(AuraMode::RainbowWave.cli_name(), "rainbow-wave");
+        assert_eq!(AuraMode::Stars.cli_name(), "stars");
+        assert_eq!(AuraMode::Rain.cli_name(), "rain");
+        assert_eq!(AuraMode::Highlight.cli_name(), "highlight");
+        assert_eq!(AuraMode::Laser.cli_name(), "laser");
+        assert_eq!(AuraMode::Ripple.cli_name(), "ripple");
+        assert_eq!(AuraMode::Pulse.cli_name(), "pulse");
+        assert_eq!(AuraMode::Comet.cli_name(), "comet");
+        assert_eq!(AuraMode::Flash.cli_name(), "flash");
+    }
+
+    #[test]
+    fn test_aura_mode_label() {
+        assert_eq!(AuraMode::Static.label(), "Static");
+        assert_eq!(AuraMode::RainbowCycle.label(), "Rainbow Cycle");
+        assert_eq!(AuraMode::RainbowWave.label(), "Rainbow Wave");
+    }
+
+    #[test]
+    fn test_aura_mode_needs_colour() {
+        // Modes that need colour
+        assert!(AuraMode::Static.needs_colour());
+        assert!(AuraMode::Breathe.needs_colour());
+        assert!(AuraMode::Stars.needs_colour());
+        assert!(AuraMode::Highlight.needs_colour());
+        assert!(AuraMode::Laser.needs_colour());
+        assert!(AuraMode::Ripple.needs_colour());
+        assert!(AuraMode::Pulse.needs_colour());
+        assert!(AuraMode::Comet.needs_colour());
+        assert!(AuraMode::Flash.needs_colour());
+
+        // Modes that don't need colour
+        assert!(!AuraMode::RainbowCycle.needs_colour());
+        assert!(!AuraMode::RainbowWave.needs_colour());
+        assert!(!AuraMode::Rain.needs_colour());
+    }
+
+    #[test]
+    fn test_aura_mode_needs_colour2() {
+        // Only Breathe and Stars need a second colour
+        assert!(AuraMode::Breathe.needs_colour2());
+        assert!(AuraMode::Stars.needs_colour2());
+
+        // Others don't
+        assert!(!AuraMode::Static.needs_colour2());
+        assert!(!AuraMode::RainbowCycle.needs_colour2());
+        assert!(!AuraMode::Laser.needs_colour2());
+    }
+
+    #[test]
+    fn test_aura_mode_needs_speed() {
+        // Modes that need speed
+        assert!(AuraMode::Breathe.needs_speed());
+        assert!(AuraMode::RainbowCycle.needs_speed());
+        assert!(AuraMode::RainbowWave.needs_speed());
+        assert!(AuraMode::Stars.needs_speed());
+        assert!(AuraMode::Rain.needs_speed());
+        assert!(AuraMode::Highlight.needs_speed());
+        assert!(AuraMode::Laser.needs_speed());
+        assert!(AuraMode::Ripple.needs_speed());
+
+        // Modes that don't need speed
+        assert!(!AuraMode::Static.needs_speed());
+        assert!(!AuraMode::Pulse.needs_speed());
+        assert!(!AuraMode::Comet.needs_speed());
+        assert!(!AuraMode::Flash.needs_speed());
+    }
+
+    #[test]
+    fn test_aura_mode_needs_direction() {
+        // Only RainbowWave needs direction
+        assert!(AuraMode::RainbowWave.needs_direction());
+
+        // Others don't
+        assert!(!AuraMode::Static.needs_direction());
+        assert!(!AuraMode::RainbowCycle.needs_direction());
+        assert!(!AuraMode::Breathe.needs_direction());
+    }
+
+    #[test]
+    fn test_aura_mode_from_dbus_value() {
+        assert_eq!(AuraMode::from_dbus_value(0), Some(AuraMode::Static));
+        assert_eq!(AuraMode::from_dbus_value(1), Some(AuraMode::Breathe));
+        assert_eq!(AuraMode::from_dbus_value(3), Some(AuraMode::RainbowCycle));
+        assert_eq!(AuraMode::from_dbus_value(4), Some(AuraMode::Stars));
+        assert_eq!(AuraMode::from_dbus_value(5), Some(AuraMode::Rain));
+        assert_eq!(AuraMode::from_dbus_value(6), Some(AuraMode::Highlight));
+        assert_eq!(AuraMode::from_dbus_value(7), Some(AuraMode::Laser));
+        assert_eq!(AuraMode::from_dbus_value(8), Some(AuraMode::Ripple));
+        assert_eq!(AuraMode::from_dbus_value(9), Some(AuraMode::Pulse));
+        assert_eq!(AuraMode::from_dbus_value(10), Some(AuraMode::Comet));
+        assert_eq!(AuraMode::from_dbus_value(11), Some(AuraMode::Flash));
+
+        // Invalid values
+        assert_eq!(AuraMode::from_dbus_value(2), None); // Strobe is not mapped
+        assert_eq!(AuraMode::from_dbus_value(12), None);
+        assert_eq!(AuraMode::from_dbus_value(100), None);
+    }
+
+    #[test]
+    fn test_aura_mode_display() {
+        assert_eq!(AuraMode::Static.to_string(), "Static");
+        assert_eq!(AuraMode::RainbowCycle.to_string(), "Rainbow Cycle");
+        assert_eq!(AuraMode::RainbowWave.to_string(), "Rainbow Wave");
+    }
+
+    #[test]
+    fn test_aura_mode_default() {
+        assert_eq!(AuraMode::default(), AuraMode::Static);
+    }
+
+    #[test]
+    fn test_aura_mode_all_constant() {
+        assert_eq!(AuraMode::ALL.len(), 12);
+        assert!(AuraMode::ALL.contains(&AuraMode::Static));
+        assert!(AuraMode::ALL.contains(&AuraMode::Flash));
+    }
+
+    // ------------------------------------------------------------------------
+    // AuraSpeed Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_aura_speed_from_str_valid() {
+        assert_eq!(AuraSpeed::from_str("low").unwrap(), AuraSpeed::Low);
+        assert_eq!(AuraSpeed::from_str("LOW").unwrap(), AuraSpeed::Low);
+        assert_eq!(AuraSpeed::from_str("med").unwrap(), AuraSpeed::Med);
+        assert_eq!(AuraSpeed::from_str("Med").unwrap(), AuraSpeed::Med);
+        assert_eq!(AuraSpeed::from_str("high").unwrap(), AuraSpeed::High);
+        assert_eq!(AuraSpeed::from_str("HIGH").unwrap(), AuraSpeed::High);
+    }
+
+    #[test]
+    fn test_aura_speed_from_str_invalid() {
+        assert!(AuraSpeed::from_str("fast").is_err());
+        assert!(AuraSpeed::from_str("").is_err());
+        assert!(AuraSpeed::from_str("medium").is_err());
+    }
+
+    #[test]
+    fn test_aura_speed_display() {
+        assert_eq!(AuraSpeed::Low.to_string(), "low");
+        assert_eq!(AuraSpeed::Med.to_string(), "med");
+        assert_eq!(AuraSpeed::High.to_string(), "high");
+    }
+
+    #[test]
+    fn test_aura_speed_default() {
+        assert_eq!(AuraSpeed::default(), AuraSpeed::Med);
+    }
+
+    // ------------------------------------------------------------------------
+    // AuraDirection Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_aura_direction_from_str_valid() {
+        assert_eq!(AuraDirection::from_str("up").unwrap(), AuraDirection::Up);
+        assert_eq!(AuraDirection::from_str("UP").unwrap(), AuraDirection::Up);
+        assert_eq!(
+            AuraDirection::from_str("down").unwrap(),
+            AuraDirection::Down
+        );
+        assert_eq!(
+            AuraDirection::from_str("Down").unwrap(),
+            AuraDirection::Down
+        );
+        assert_eq!(
+            AuraDirection::from_str("left").unwrap(),
+            AuraDirection::Left
+        );
+        assert_eq!(
+            AuraDirection::from_str("LEFT").unwrap(),
+            AuraDirection::Left
+        );
+        assert_eq!(
+            AuraDirection::from_str("right").unwrap(),
+            AuraDirection::Right
+        );
+        assert_eq!(
+            AuraDirection::from_str("Right").unwrap(),
+            AuraDirection::Right
+        );
+    }
+
+    #[test]
+    fn test_aura_direction_from_str_invalid() {
+        assert!(AuraDirection::from_str("north").is_err());
+        assert!(AuraDirection::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_aura_direction_display() {
+        assert_eq!(AuraDirection::Up.to_string(), "up");
+        assert_eq!(AuraDirection::Down.to_string(), "down");
+        assert_eq!(AuraDirection::Left.to_string(), "left");
+        assert_eq!(AuraDirection::Right.to_string(), "right");
+    }
+
+    #[test]
+    fn test_aura_direction_default() {
+        assert_eq!(AuraDirection::default(), AuraDirection::Right);
+    }
+
+    // ------------------------------------------------------------------------
+    // SlashMode Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_slash_mode_from_str_valid() {
+        assert_eq!(SlashMode::from_str("Static").unwrap(), SlashMode::Static);
+        assert_eq!(SlashMode::from_str("Bounce").unwrap(), SlashMode::Bounce);
+        assert_eq!(SlashMode::from_str("Slash").unwrap(), SlashMode::Slash);
+        assert_eq!(SlashMode::from_str("Loading").unwrap(), SlashMode::Loading);
+        assert_eq!(
+            SlashMode::from_str("BitStream").unwrap(),
+            SlashMode::BitStream
+        );
+        assert_eq!(
+            SlashMode::from_str("Transmission").unwrap(),
+            SlashMode::Transmission
+        );
+        assert_eq!(SlashMode::from_str("Flow").unwrap(), SlashMode::Flow);
+        assert_eq!(SlashMode::from_str("Flux").unwrap(), SlashMode::Flux);
+        assert_eq!(SlashMode::from_str("Phantom").unwrap(), SlashMode::Phantom);
+        assert_eq!(
+            SlashMode::from_str("Spectrum").unwrap(),
+            SlashMode::Spectrum
+        );
+        assert_eq!(SlashMode::from_str("Hazard").unwrap(), SlashMode::Hazard);
+        assert_eq!(
+            SlashMode::from_str("Interfacing").unwrap(),
+            SlashMode::Interfacing
+        );
+        assert_eq!(SlashMode::from_str("Ramp").unwrap(), SlashMode::Ramp);
+        assert_eq!(
+            SlashMode::from_str("GameOver").unwrap(),
+            SlashMode::GameOver
+        );
+        assert_eq!(SlashMode::from_str("Start").unwrap(), SlashMode::Start);
+        assert_eq!(SlashMode::from_str("Buzzer").unwrap(), SlashMode::Buzzer);
+    }
+
+    #[test]
+    fn test_slash_mode_from_str_invalid() {
+        assert!(SlashMode::from_str("invalid").is_err());
+        assert!(SlashMode::from_str("").is_err());
+        // Note: SlashMode uses case-sensitive matching unlike other enums
+        assert!(SlashMode::from_str("static").is_err());
+        assert!(SlashMode::from_str("STATIC").is_err());
+    }
+
+    #[test]
+    fn test_slash_mode_display() {
+        assert_eq!(SlashMode::Static.to_string(), "Static");
+        assert_eq!(SlashMode::BitStream.to_string(), "BitStream");
+        assert_eq!(SlashMode::GameOver.to_string(), "GameOver");
+    }
+
+    #[test]
+    fn test_slash_mode_default() {
+        assert_eq!(SlashMode::default(), SlashMode::Flow);
+    }
+
+    // ------------------------------------------------------------------------
+    // SlashState Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_slash_state_default() {
+        let state = SlashState::default();
+        assert!(!state.enabled);
+        assert_eq!(state.brightness, 0);
+        assert_eq!(state.interval, 0);
+        assert_eq!(state.mode, SlashMode::Flow);
+    }
+
+    // ------------------------------------------------------------------------
+    // ProfileState Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_profile_state_default() {
+        let state = ProfileState::default();
+        assert_eq!(state.active, PowerProfile::Balanced);
+        assert_eq!(state.on_ac, PowerProfile::Balanced);
+        assert_eq!(state.on_battery, PowerProfile::Balanced);
+    }
+
+    // ------------------------------------------------------------------------
+    // AuraModeData Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_aura_mode_data_default() {
+        let data = AuraModeData::default();
+        assert_eq!(data.mode, AuraMode::Static);
+        assert_eq!(data.zone, 0);
+        assert_eq!(data.color1, (0, 0, 0));
+        assert_eq!(data.color2, (0, 0, 0));
+        assert_eq!(data.speed, AuraSpeed::Med);
+        assert_eq!(data.direction, AuraDirection::Right);
+    }
+
+    // ------------------------------------------------------------------------
+    // SupportedFeatures Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_supported_features_default() {
+        let features = SupportedFeatures::default();
+        assert!(!features.asusctl_installed);
+        assert!(!features.asusd_running);
+        assert!(!features.has_aura);
+        assert!(!features.has_platform);
+        assert!(!features.has_fan_curves);
+        assert!(!features.has_slash);
+        assert!(features.keyboard_brightness_levels.is_empty());
+        assert!(features.aura_modes.is_empty());
+        assert!(features.aura_zones.is_empty());
+        assert!(!features.has_charge_control);
+        assert!(!features.has_throttle_policy);
+    }
+
+    // ------------------------------------------------------------------------
+    // SystemInfo Tests
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_system_info_default() {
+        let info = SystemInfo::default();
+        assert!(info.asusctl_version.is_empty());
+        assert!(info.product_family.is_empty());
+        assert!(info.board_name.is_empty());
+    }
+}


### PR DESCRIPTION
## Changes
- `types.rs` - Tests for FromStr, Display, defaults for all enums and structs
- `aura.rs` - Tests for hsv_to_hex color conversion and rainbow effect calculations
- `slash.rs` - Tests for config parsing helpers (extract_number, extract_string_value)
- `power.rs` - Tests for profile state parsing across different output formats
- `system.rs` - Tests for system info and feature detection parsing
- `error.rs` - Tests for error Display, Debug, Clone traits

## Test count
- Before: 4 tests
- After: 96 tests
