### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/Bl4ckspell7/asusctl-gui/security/code-scanning/1](https://github.com/Bl4ckspell7/asusctl-gui/security/code-scanning/1)

In general, to fix this issue you should explicitly declare a `permissions:` block at the workflow root or per job, specifying the minimal scopes required. For a simple CI workflow that only checks out code, uses caches, and builds/tests without interacting with pull requests or writing to the repository, `contents: read` is typically sufficient.

The best fix here, without changing existing functionality, is to add a workflow-level `permissions:` block directly under the `name: Rust` line (before `on:`). This will apply to all jobs (currently just `build`) unless they override it. Given the steps shown (checkout, cache, install dependencies, build, test), the job only needs read access to repository contents, so we can safely set:
```yaml
permissions:
  contents: read
```
No additional methods, functions, or imports are needed; this is a pure YAML configuration change in `.github/workflows/rust.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
