### PR TITLE
chore: add cargo ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `cargo` package ecosystem to Dependabot configuration to automate Rust dependency updates on a weekly schedule.

## Test plan
- [ ] Verify Dependabot picks up `Cargo.toml` and opens PRs for outdated dependencies
