### PR TITLE
feat: add asus-armoury driver detection on about page

### DIFF
--- a/src/backend/dbus.rs
+++ b/src/backend/dbus.rs
@@ -12,6 +12,7 @@ pub const PLATFORM_INTERFACE: &str = "xyz.ljones.Platform";
 pub const AURA_BASE_PATH: &str = "/xyz/ljones/aura";
 pub const AURA_INTERFACE: &str = "xyz.ljones.Aura";
 pub const SLASH_INTERFACE: &str = "xyz.ljones.Slash";
+pub const ARMOURY_INTERFACE: &str = "xyz.ljones.AsusArmoury";
 
 // Config file paths (fallback)
 pub const SLASH_CONFIG_PATH: &str = "/etc/asusd/slash.ron";
@@ -197,4 +198,38 @@ pub fn get_slash_path() -> Option<&'static String> {
             None
         })
         .as_ref()
+}
+
+/// Check if the asus-armoury D-Bus interface is available.
+///
+/// Enumerates paths under `xyz.ljones.Asusd` and checks for any that
+/// implement the `xyz.ljones.AsusArmoury` interface, which indicates
+/// the asus-armoury kernel driver is loaded.
+pub fn has_armoury_interface() -> bool {
+    let output = Command::new("busctl")
+        .args(["--system", "tree", "--list", DBUS_DEST])
+        .output()
+        .ok();
+
+    let Some(output) = output else {
+        return false;
+    };
+
+    if !output.status.success() {
+        return false;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let paths: Vec<&str> = stdout
+        .lines()
+        .filter(|line| line.starts_with("/xyz/ljones/asus_armoury/"))
+        .collect();
+
+    for path in paths {
+        if path_has_interface(path, ARMOURY_INTERFACE, "Name") {
+            return true;
+        }
+    }
+
+    false
 }

--- a/src/backend/system.rs
+++ b/src/backend/system.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 use std::sync::OnceLock;
 
 use super::dbus::{
-    PLATFORM_INTERFACE, PLATFORM_PATH, get_aura_path, get_slash_path, read_dbus_property_at,
-    run_asusctl,
+    PLATFORM_INTERFACE, PLATFORM_PATH, get_aura_path, get_slash_path, has_armoury_interface,
+    read_dbus_property_at, run_asusctl,
 };
 use super::error::{AsusctlError, Result};
 use super::types::{AuraMode, KeyboardBrightness, SupportedFeatures, SystemInfo};
@@ -98,6 +98,8 @@ fn probe_dbus_features(features: &mut SupportedFeatures) {
         features.has_throttle_policy = true;
     }
 
+    features.has_armoury = has_armoury_interface();
+
     if features.has_aura || features.has_slash || features.has_platform {
         features.asusd_running = true;
     }
@@ -137,6 +139,7 @@ fn parse_supported_features(output: &str) -> Result<SupportedFeatures> {
     features.has_platform = output.contains("xyz.ljones.Platform");
     features.has_fan_curves = output.contains("xyz.ljones.FanCurves");
     features.has_slash = output.contains("xyz.ljones.Slash");
+    features.has_armoury = output.contains("xyz.ljones.AsusArmoury");
 
     // Parse platform properties
     features.has_charge_control = output.contains("ChargeControlEndThreshold");

--- a/src/backend/types.rs
+++ b/src/backend/types.rs
@@ -445,6 +445,7 @@ pub struct SupportedFeatures {
     pub aura_zones: Vec<String>,
     pub has_charge_control: bool,
     pub has_throttle_policy: bool,
+    pub has_armoury: bool,
 }
 
 // ============================================================================
@@ -962,6 +963,7 @@ mod tests {
         assert!(features.aura_zones.is_empty());
         assert!(!features.has_charge_control);
         assert!(!features.has_throttle_policy);
+        assert!(!features.has_armoury);
     }
 
     // ------------------------------------------------------------------------

--- a/src/ui/pages/about.rs
+++ b/src/ui/pages/about.rs
@@ -146,6 +146,7 @@ impl AboutPage {
         let service_status = [
             ("asusctl Installed", features.asusctl_installed),
             ("asusd Service Running", features.asusd_running),
+            ("asus-armoury Driver", features.has_armoury),
         ];
 
         for (name, available) in service_status {


### PR DESCRIPTION
## Summary
Detect whether the asus-armoury kernel driver is loaded by checking for
`xyz.ljones.AsusArmoury` D-Bus interfaces exposed by `asusd`, and display
the result as a status row on the About page.