### PR TITLE
feat: add distro and kernel version, reorganize about page sections

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -34,7 +34,7 @@ pub use types::{
 };
 
 // Re-export system functions
-pub use system::{detect_features, get_system_info};
+pub use system::{detect_features, get_distro, get_kernel_version, get_system_info};
 
 // Re-export aura functions
 pub use aura::{

--- a/src/backend/system.rs
+++ b/src/backend/system.rs
@@ -1,5 +1,6 @@
 //! System information and feature detection.
 
+use std::fs;
 use std::str::FromStr;
 use std::sync::OnceLock;
 
@@ -20,6 +21,24 @@ static DETECTED_FEATURES: OnceLock<SupportedFeatures> = OnceLock::new();
 pub fn get_system_info() -> Result<SystemInfo> {
     let output = run_asusctl(&["info"])?;
     parse_system_info(&output)
+}
+
+/// Get the Linux kernel version from /proc/sys/kernel/osrelease.
+pub fn get_kernel_version() -> String {
+    fs::read_to_string("/proc/sys/kernel/osrelease")
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Get the Linux distribution name from /etc/os-release (PRETTY_NAME field).
+pub fn get_distro() -> String {
+    let content = fs::read_to_string("/etc/os-release").unwrap_or_default();
+    for line in content.lines() {
+        if let Some(value) = line.strip_prefix("PRETTY_NAME=") {
+            return value.trim_matches('"').to_string();
+        }
+    }
+    String::new()
 }
 
 /// Detect available features once and cache the result for the process lifetime.

--- a/src/ui/pages/about.rs
+++ b/src/ui/pages/about.rs
@@ -87,9 +87,21 @@ impl AboutPage {
             .subtitle("Loading...")
             .build();
 
+        let distro_row = adw::ActionRow::builder()
+            .title("Distribution")
+            .subtitle(&backend::get_distro())
+            .build();
+
+        let kernel_row = adw::ActionRow::builder()
+            .title("Kernel Version")
+            .subtitle(&backend::get_kernel_version())
+            .build();
+
         laptop_group.add(&model_row);
         laptop_group.add(&driver_row);
         laptop_group.add(&asusctl_row);
+        laptop_group.add(&distro_row);
+        laptop_group.add(&kernel_row);
 
         // Store references
         imp.model_row.replace(Some(model_row));
@@ -98,14 +110,21 @@ impl AboutPage {
 
         self.append(&laptop_group);
 
-        // Supported features group (loaded once from cached detection)
+        // Service status group
+        let status_group = adw::PreferencesGroup::builder()
+            .title("Service Status")
+            .build();
+
+        // Supported features group
         let features_group = adw::PreferencesGroup::builder()
             .title("Supported Features")
             .build();
 
         let features = backend::detect_features();
+        Self::populate_status(&status_group, features);
         Self::populate_features(&features_group, features);
 
+        self.append(&status_group);
         self.append(&features_group);
     }
 
@@ -141,16 +160,18 @@ impl AboutPage {
         }
     }
 
-    fn populate_features(group: &adw::PreferencesGroup, features: &backend::SupportedFeatures) {
-        // Service status
+    fn populate_status(group: &adw::PreferencesGroup, features: &backend::SupportedFeatures) {
         let service_status = [
-            ("asusctl Installed", features.asusctl_installed),
-            ("asusd Service Running", features.asusd_running),
-            ("asus-armoury Driver", features.has_armoury),
+            ("Installed", "asusctl", features.asusctl_installed),
+            ("Service Running", "asusd", features.asusd_running),
+            ("Driver Loaded", "asus-armoury", features.has_armoury),
         ];
 
-        for (name, available) in service_status {
-            let row = adw::ActionRow::builder().title(name).build();
+        for (title, subtitle, available) in service_status {
+            let row = adw::ActionRow::builder()
+                .title(title)
+                .subtitle(subtitle)
+                .build();
 
             let icon_name = if available {
                 "object-select-symbolic"
@@ -168,7 +189,9 @@ impl AboutPage {
 
             group.add(&row);
         }
+    }
 
+    fn populate_features(group: &adw::PreferencesGroup, features: &backend::SupportedFeatures) {
         // Core features
         let core_features = [
             ("Aura (Keyboard Lighting)", features.has_aura),


### PR DESCRIPTION
## Summary
- Add Linux distribution and kernel version rows to the Laptop Information section
- Split features list into separate "Service Status" and "Supported Features" groups
- Use title/subtitle hierarchy for service status rows to visually distinguish service names

## Screenshot
<img width="1780" height="2494" alt="Screenshot From 2026-02-11 10-40-11" src="https://github.com/user-attachments/assets/2a80f19a-ab11-41db-83c0-2f51673b77c5" />
