### PR TITLE
fix: remove stack transition to prevent page switch flicker

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -148,7 +148,7 @@ impl AsusctlGuiWindow {
 
         // Create the content stack for pages
         let stack = gtk4::Stack::builder()
-            .transition_type(gtk4::StackTransitionType::Crossfade)
+            .transition_type(gtk4::StackTransitionType::None)
             .hhomogeneous(false)
             .vhomogeneous(false)
             .build();


### PR DESCRIPTION
## Summary

- Remove the `Crossfade` stack transition that caused a visual glitch when switching pages
- The crossfade composited both pages simultaneously in a non-homogeneous stack, causing brief layout artifacts during the transition

Closes #5
