### PR TITLE
feat(ci): add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump (auto = derive from Conventional Commits)"
+        type: choice
+        default: auto
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: "Dry run: compute version + notes only (no commit/tag/release)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50@sha256:9b485ec99dd7a32966475e88e23add82e74162987e662dd0dcaaf26cdbb3de20
+      options: --privileged
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
+      - name: Install git-cliff
+        env:
+          UV_TOOL_BIN_DIR: /usr/local/bin
+        run: |
+          uv tool install 'git-cliff==2.13.1'
+          git-cliff --version
+
+      - name: Compute version
+        id: ver
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          version="$(bash scripts/release/bump.sh compute "$BUMP")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Computed version: v$version"
+
+      - name: Preview release (dry run)
+        if: ${{ inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          {
+            echo "## Dry run — would release \`v${VERSION}\`"
+            echo
+            echo '```markdown'
+            git cliff --tag "v${VERSION}" --unreleased --strip all || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Apply version bump
+        if: ${{ ! inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          RELEASE_NOTES: ${{ runner.temp }}/release-notes.md
+        run: bash scripts/release/bump.sh apply "$VERSION"
+
+      - name: Build Flatpak bundle
+        if: ${{ ! inputs.dry_run }}
+        uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb # v6.7
+        with:
+          manifest-path: com.github.bl4ckspell7.asusctl-gui.yml
+          bundle: asusctl-gui.flatpak
+          upload-artifact: false
+
+      - name: Generate checksums
+        if: ${{ ! inputs.dry_run }}
+        run: sha256sum asusctl-gui.flatpak > SHA256SUMS.txt
+
+      - name: Commit, tag and push
+        if: ${{ ! inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git add Cargo.toml Cargo.lock CHANGELOG.md data/com.github.bl4ckspell7.asusctl-gui.metainfo.xml
+          git commit -m "chore(release): v${VERSION}"
+          git tag "v${VERSION}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "v${VERSION}"
+
+      - name: Create draft release
+        if: ${{ ! inputs.dry_run }}
+        # zizmor: ignore[superfluous-actions] — `gh` CLI is not in the flatpak container; this action runs via runner-injected node
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          draft: true
+          tag_name: v${{ steps.ver.outputs.version }}
+          body_path: ${{ runner.temp }}/release-notes.md
+          generate_release_notes: false
+          files: |
+            asusctl-gui.flatpak
+            SHA256SUMS.txt

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,6 +126,7 @@ Releases are cut by the **Release** workflow (`.github/workflows/release.yml`) �
    - `patch` / `minor` / `major` — force a level.
 
    Leave **`dry_run` checked** the first time.
+
 2. **Review the dry-run job summary** — it prints the computed version and release notes without changing anything.
 3. **Re-run with `dry_run` unchecked.** The workflow bumps the version (`Cargo.toml`, `Cargo.lock`, metainfo), updates `CHANGELOG.md`, builds the Flatpak bundle, commits + tags `vX.Y.Z`, and opens a **draft** GitHub Release with the bundle + `SHA256SUMS.txt`.
 4. **Review the draft, then publish it.** Publishing locks the tag and assets ([immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)) and generates a build attestation.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -116,3 +116,27 @@ Generate text summary:
 ```bash
 cargo llvm-cov
 ```
+
+## Releasing
+
+Releases are cut by the **Release** workflow (`.github/workflows/release.yml`) — triggered manually, never on push. Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org); the version bump and changelog are derived from them.
+
+1. **Actions → Release → Run workflow**, and pick the bump:
+   - `auto` (default) — derived from commits since the last tag (`feat` → minor, `fix` → patch, breaking → major).
+   - `patch` / `minor` / `major` — force a level.
+
+   Leave **`dry_run` checked** the first time.
+2. **Review the dry-run job summary** — it prints the computed version and release notes without changing anything.
+3. **Re-run with `dry_run` unchecked.** The workflow bumps the version (`Cargo.toml`, `Cargo.lock`, metainfo), updates `CHANGELOG.md`, builds the Flatpak bundle, commits + tags `vX.Y.Z`, and opens a **draft** GitHub Release with the bundle + `SHA256SUMS.txt`.
+4. **Review the draft, then publish it.** Publishing locks the tag and assets ([immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)) and generates a build attestation.
+
+### Preview locally (optional)
+
+```bash
+uv tool install git-cliff
+```
+
+```bash
+git cliff --bumped-version   # next version
+git cliff --unreleased       # notes for the upcoming release
+```

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,41 @@
+# git-cliff configuration — https://git-cliff.org/docs/configuration
+# Generates CHANGELOG.md and per-release notes from Conventional Commits,
+# and drives `git cliff --bumped-version` for the release workflow.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+"""
+body = """
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {% if commit.scope %}*({{ commit.scope }})* {% endif %}{% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }}\
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+footer = ""
+
+[git]
+# Only deviations from git-cliff defaults live here. First match wins. The
+# `<!-- N -->` prefixes order the groups; `striptags` in the template strips them.
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->Features" },
+    { message = "^fix\\(ci\\)", skip = true },
+    { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
+    { message = "^perf", group = "<!-- 2 -->Performance" },
+    { message = "^refactor", group = "<!-- 3 -->Refactor" },
+    { message = "^docs?", group = "<!-- 4 -->Documentation" },
+    { message = "^(chore|ci|build|actions|style|test)", skip = true },
+    { message = "^revert", group = "<!-- 5 -->Reverts" },
+    { message = ".*", group = "<!-- 6 -->Other" },
+]

--- a/scripts/release/bump.sh
+++ b/scripts/release/bump.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Release version helper for asusctl-gui.
+#
+#   bump.sh compute <auto|patch|minor|major>
+#       Print the next version (no leading "v"). Read-only.
+#
+#   bump.sh apply <version>
+#       Bump the version in Cargo.toml, Cargo.lock and the AppStream metainfo,
+#       (re)generate CHANGELOG.md and write this release's notes to
+#       $RELEASE_NOTES (default /tmp/release-notes.md). Mutates the tree.
+#
+# "auto" derives the bump from Conventional Commits via git-cliff. The very
+# first release (no tags yet) uses the current Cargo.toml version as-is.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CARGO_TOML="Cargo.toml"
+CARGO_LOCK="Cargo.lock"
+METAINFO="data/com.github.bl4ckspell7.asusctl-gui.metainfo.xml"
+RELEASE_NOTES="${RELEASE_NOTES:-/tmp/release-notes.md}"
+REPO_URL="https://github.com/Bl4ckspell7/asusctl-gui"
+
+# Current version: first `version = "x"` inside the [package] table.
+current_version() {
+    sed -nE '/^\[package\]/,/^\[/{s/^version = "([^"]+)".*/\1/p}' "$CARGO_TOML" | head -n1
+}
+
+# Highest existing release tag, without the leading "v".
+latest_tag_version() {
+    git tag --list 'v[0-9]*' --sort=-v:refname | head -n1 | sed 's/^v//'
+}
+
+# bump_semver <x.y.z> <major|minor|patch>
+bump_semver() {
+    local IFS=. ma mi pa
+    read -r ma mi pa <<<"$1"
+    case "$2" in
+        major) echo "$((ma + 1)).0.0" ;;
+        minor) echo "${ma}.$((mi + 1)).0" ;;
+        patch) echo "${ma}.${mi}.$((pa + 1))" ;;
+        *)
+            echo "unknown bump level: $2" >&2
+            exit 1
+            ;;
+    esac
+}
+
+compute() {
+    local level="${1:-auto}" base next
+    # First release: no tags yet -> keep the current Cargo.toml version.
+    if [ -z "$(git tag --list 'v[0-9]*')" ]; then
+        current_version
+        return
+    fi
+    base="$(latest_tag_version)"
+    [ -n "$base" ] || base="$(current_version)"
+    case "$level" in
+        auto)
+            next="$(git cliff --bumped-version 2>/dev/null | sed 's/^v//')" || true
+            # git-cliff returns the current version when nothing is bumpable.
+            if [ -z "$next" ] || [ "$next" = "$base" ]; then
+                next="$(bump_semver "$base" patch)"
+            fi
+            echo "$next"
+            ;;
+        *)
+            bump_semver "$base" "$level"
+            ;;
+    esac
+}
+
+# Insert a new <release> as the first child of <releases>.
+insert_metainfo_release() {
+    local v="$1" d="$2" block
+    block=$(
+        cat <<EOF
+        <release version="$v" date="$d">
+            <url type="details">$REPO_URL/releases/tag/v$v</url>
+            <description>
+                <p>See the release notes.</p>
+            </description>
+        </release>
+EOF
+    )
+    awk -v ins="$block" '
+    { print }
+    /<releases>/ && !done { print ins; done = 1 }
+  ' "$METAINFO" >"$METAINFO.tmp"
+    mv "$METAINFO.tmp" "$METAINFO"
+}
+
+apply() {
+    local v="${1:?version required}" today
+    today="$(date +%F)"
+
+    # Cargo.toml: the version inside [package].
+    sed -i -E '/^\[package\]/,/^\[/{s/^version = "[^"]+"/version = "'"$v"'"/}' "$CARGO_TOML"
+
+    # Cargo.lock: the asusctl-gui package entry (version is the line after name).
+    sed -i '/^name = "asusctl-gui"$/{n;s/^version = "[^"]*"/version = "'"$v"'"/}' "$CARGO_LOCK"
+
+    # AppStream metainfo release entry.
+    insert_metainfo_release "$v" "$today"
+
+    # Changelog + this release's notes (Conventional Commits via git-cliff).
+    git cliff --tag "v$v" -o CHANGELOG.md
+    git cliff --tag "v$v" --unreleased --strip all >"$RELEASE_NOTES"
+}
+
+case "${1:-}" in
+    compute) compute "${2:-auto}" ;;
+    apply) apply "${2:-}" ;;
+    *)
+        echo "usage: $0 {compute <auto|patch|minor|major>|apply <version>}" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Closes #25.

Manually-triggered (`workflow_dispatch`) release workflow with semantic
versioning — via **git-cliff** (Rust-native) instead of the Node
`semantic-release` tool.

- Version from Conventional Commits (`auto`), or forced `patch`/`minor`/`major`
- Bumps Cargo.toml, Cargo.lock, AppStream metainfo; writes CHANGELOG.md + notes
- Builds the Flatpak bundle → **draft** GitHub Release
  (`asusctl-gui.flatpak` + `SHA256SUMS.txt`) for manual publish (immutable-friendly)
- `dry_run` preview is the default

New: `cliff.toml`, `scripts/release/bump.sh`; process documented in DEVELOPMENT.md.