### PR TITLE
fix(backend): detect missing asusctl under Flatpak

### DIFF
--- a/src/backend/dbus.rs
+++ b/src/backend/dbus.rs
@@ -54,16 +54,28 @@ pub fn run_asusctl(args: &[&str]) -> Result<String> {
     })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    interpret_asusctl_output(output.status.success(), stdout, &stderr)
+}
 
-    // Check for common error patterns
+/// Classify an asusctl invocation's result. Separated from process spawning so
+/// the logic is unit-testable.
+///
+/// - stderr mentioning the service / a refused connection -> `ServiceNotRunning`
+///   (asusctl is present but `asusd` is unreachable).
+/// - non-zero exit with empty stdout -> `NotInstalled`. Under
+///   `flatpak-spawn --host` a missing host `asusctl` exits 127 with empty
+///   stdout (flatpak-spawn itself runs, so it is not caught as a NotFound
+///   spawn error). asusctl often exits non-zero *with* useful stdout, so only
+///   the empty-output failure is treated as missing.
+/// - otherwise -> stdout as-is.
+fn interpret_asusctl_output(success: bool, stdout: String, stderr: &str) -> Result<String> {
     if stderr.contains("Connection refused") || stderr.contains("asusd") {
         return Err(AsusctlError::ServiceNotRunning);
     }
-
-    // Note: asusctl often returns non-zero but still provides useful output
-    let _ = output.status.success();
-
+    if !success && stdout.trim().is_empty() {
+        return Err(AsusctlError::NotInstalled);
+    }
     Ok(stdout)
 }
 
@@ -266,3 +278,7 @@ pub fn has_armoury_interface() -> bool {
 
     false
 }
+
+#[cfg(test)]
+#[path = "tests/dbus_tests.rs"]
+mod tests;

--- a/src/backend/tests/dbus_tests.rs
+++ b/src/backend/tests/dbus_tests.rs
@@ -1,0 +1,46 @@
+use super::*;
+use crate::backend::error::AsusctlError;
+
+#[test]
+fn missing_binary_empty_output_is_not_installed() {
+    // flatpak-spawn exits non-zero (127) with empty stdout when the host
+    // asusctl is absent — the bug this guards against.
+    let result = interpret_asusctl_output(false, String::new(), "");
+    assert!(matches!(result, Err(AsusctlError::NotInstalled)));
+}
+
+#[test]
+fn whitespace_only_output_with_failure_is_not_installed() {
+    let result = interpret_asusctl_output(false, "   \n".to_string(), "");
+    assert!(matches!(result, Err(AsusctlError::NotInstalled)));
+}
+
+#[test]
+fn asusd_unreachable_is_service_not_running() {
+    let refused = interpret_asusctl_output(false, String::new(), "Error: Connection refused");
+    assert!(matches!(refused, Err(AsusctlError::ServiceNotRunning)));
+
+    let no_asusd = interpret_asusctl_output(false, String::new(), "failed to connect to asusd");
+    assert!(matches!(no_asusd, Err(AsusctlError::ServiceNotRunning)));
+}
+
+#[test]
+fn service_error_takes_precedence_over_empty_output() {
+    // Empty stdout + failure, but the stderr shows asusd is down: asusctl IS
+    // installed, the service just isn't running.
+    let result = interpret_asusctl_output(false, String::new(), "asusd: Connection refused");
+    assert!(matches!(result, Err(AsusctlError::ServiceNotRunning)));
+}
+
+#[test]
+fn nonzero_exit_with_output_is_ok() {
+    // asusctl frequently exits non-zero while still printing useful output.
+    let result = interpret_asusctl_output(false, "Product family: ROG".to_string(), "");
+    assert_eq!(result.unwrap(), "Product family: ROG");
+}
+
+#[test]
+fn success_returns_stdout() {
+    let result = interpret_asusctl_output(true, "ok".to_string(), "");
+    assert_eq!(result.unwrap(), "ok");
+}


### PR DESCRIPTION
On a system without asusctl, the **Flatpak** build wrongly reported asusctl
**Installed ✓** / asusd **Service Running ✓** (with an empty `v` version).

**Cause:** under `flatpak-spawn --host`, a missing host `asusctl` doesn't raise a
NotFound spawn error (flatpak-spawn itself runs) — it exits 127 with empty
stdout. `run_asusctl` ignored the exit status and returned `Ok("")`, so
`detect_features` took the success path and marked everything present. Native
builds were already correct.

**Fix:** treat a non-zero exit with empty stdout as `NotInstalled`.
Classification extracted into a pure `interpret_asusctl_output()` helper + 6
unit tests.

Verify: `cargo test` (76 pass); rebuild the Flatpak on a clean VM → About shows
Installed ✗ / Service Running ✗.