### PR TITLE
ci(renovate): pin renovate image

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           configurationFile: renovate.json
           token: ${{ secrets.GITHUB_TOKEN }}
+          # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
+          renovate-version: 43.278.3@sha256:8aa63d0b2a0ec65cc7a01d1584faab39a90046f0f840af28e98ae295dc12cd75
         env:
           RENOVATE_ALLOWED_COMMANDS: '["^bash scripts/regen-cargo-sources\\.sh$"]'
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,13 @@
       "matchStrings": ["install-tool python (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
       "datasourceTemplate": "python-version",
       "depNameTemplate": "python"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/renovate\\.yml$/"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s*\\n\\s*renovate-version:\\s*(?<currentValue>[^\\s@]+)(@(?<currentDigest>sha256:[a-f0-9]+))?"
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

The Renovate action defaults to the floating `ghcr.io/renovatebot/renovate:43` tag, so every scheduled run could pull a different image. This pins the exact version plus digest and lets Renovate keep that pin current.

- Set `renovate-version: 43.278.3@sha256:8aa63d0b…` on the `renovatebot/github-action` step
- Add a custom regex manager for `.github/workflows/renovate.yml` so the pin self-updates
- Verified against the pinned image: `--version` reports `43.278.3`, `renovate-config-validator` passes, and a full local dry run extracts the dep and proposes `43.285.3@sha256:a1059bb5…` on `renovate/ghcr.io-renovatebot-renovate-43.x`