### PR TITLE
feat(about): add BIOS, vendor and serial number info

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -14,6 +14,7 @@
 //! - [`error`] - Error types and Result alias
 //! - [`types`] - Data structures (enums, structs)
 //! - [`dbus`] - D-Bus communication helpers (internal)
+//! - [`dmi`] - DMI/SMBIOS information from sysfs
 //! - [`system`] - System info and feature detection
 //! - [`aura`] - Keyboard brightness and lighting control
 //! - [`power`] - Power profiles and charge control
@@ -21,6 +22,7 @@
 
 mod aura;
 mod dbus;
+mod dmi;
 mod error;
 mod power;
 mod slash;
@@ -35,6 +37,9 @@ pub use types::{
 
 // Re-export system functions
 pub use system::{detect_features, get_distro, get_kernel_version, get_system_info};
+
+// Re-export DMI functions
+pub use dmi::{format_bios, get_dmi_info, read_serial_number};
 
 // Re-export aura functions
 pub use aura::{

--- a/src/backend/dmi.rs
+++ b/src/backend/dmi.rs
@@ -1,0 +1,140 @@
+//! DMI/SMBIOS information from `/sys/class/dmi/id`.
+//!
+//! Most fields there are world-readable, so they are read directly even inside
+//! the Flatpak sandbox (`/sys` is bind-mounted read-only). The serial number is
+//! the exception: `product_serial` is mode 0400 root, so it is read on demand
+//! through `pkexec`, which triggers a polkit prompt.
+
+use std::fs;
+use std::sync::OnceLock;
+
+use super::dbus::host_command;
+use super::error::{AsusctlError, Result};
+use super::types::DmiInfo;
+
+const DMI_DIR: &str = "/sys/class/dmi/id";
+const DMI_SERIAL_PATH: &str = "/sys/class/dmi/id/product_serial";
+
+/// Placeholder values OEMs leave in the SMBIOS tables. Compared case-insensitively.
+const DMI_PLACEHOLDERS: &[&str] = &[
+    "default string",
+    "to be filled by o.e.m.",
+    "system serial number",
+    "not specified",
+    "not applicable",
+    "none",
+    "unknown",
+    "n/a",
+];
+
+static DMI_INFO: OnceLock<DmiInfo> = OnceLock::new();
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Read the world-readable DMI fields once and cache them for the process lifetime.
+///
+/// Fields that are missing or contain OEM placeholder text come back empty; the
+/// UI decides how to present that.
+pub fn get_dmi_info() -> &'static DmiInfo {
+    DMI_INFO.get_or_init(|| DmiInfo {
+        bios_version: read_dmi_field("bios_version"),
+        bios_date: read_dmi_field("bios_date"),
+        bios_vendor: read_dmi_field("bios_vendor"),
+        board_vendor: read_dmi_field("board_vendor"),
+    })
+}
+
+/// Read the machine serial number via `pkexec cat` (polkit prompt).
+///
+/// Blocks until the user answers the polkit dialog, so callers must run this
+/// off the main loop.
+///
+/// `Ok(None)` means the read succeeded but the firmware has no real serial
+/// (placeholder text) — retrying will not help. `Err` means the read itself
+/// failed, e.g. because authorization was refused.
+pub fn read_serial_number() -> Result<Option<String>> {
+    let output = host_command("pkexec")
+        .args(["cat", DMI_SERIAL_PATH])
+        .output()
+        .map_err(|e| AsusctlError::CommandFailed(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(interpret_pkexec_failure(output.status.code()));
+    }
+
+    let serial = sanitize_dmi_value(&String::from_utf8_lossy(&output.stdout));
+    if serial.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(serial))
+}
+
+// ============================================================================
+// Parsing Functions
+// ============================================================================
+
+/// Read a single sysfs DMI attribute, returning an empty string when it is
+/// unreadable or holds a placeholder value.
+fn read_dmi_field(name: &str) -> String {
+    fs::read_to_string(format!("{DMI_DIR}/{name}"))
+        .map(|value| sanitize_dmi_value(&value))
+        .unwrap_or_default()
+}
+
+/// Trim a raw DMI value and blank out well-known OEM placeholder text.
+fn sanitize_dmi_value(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let lowered = trimmed.to_lowercase();
+    if DMI_PLACEHOLDERS.contains(&lowered.as_str()) {
+        return String::new();
+    }
+    trimmed.to_string()
+}
+
+/// Turn a `pkexec` exit code into an actionable error.
+///
+/// pkexec reserves 126 for "authorization could not be obtained" (the dialog
+/// was dismissed or the password was wrong) and 127 for "pkexec/the program
+/// could not be found". Anything else came from `cat` itself.
+fn interpret_pkexec_failure(code: Option<i32>) -> AsusctlError {
+    match code {
+        Some(126) => AsusctlError::CommandFailed("Authorization was not granted".to_string()),
+        Some(127) => AsusctlError::CommandFailed("pkexec is not available".to_string()),
+        Some(code) => AsusctlError::CommandFailed(format!("pkexec cat exited with code {code}")),
+        None => AsusctlError::CommandFailed("pkexec was terminated by a signal".to_string()),
+    }
+}
+
+/// Convert an SMBIOS BIOS release date (`MM/DD/YYYY`) to ISO 8601 `YYYY-MM-DD`.
+///
+/// Returns `None` for anything that does not match that shape, so callers can
+/// fall back to the raw firmware string.
+fn to_iso_date(raw: &str) -> Option<String> {
+    let mut parts = raw.split('/');
+    let month: u32 = parts.next()?.parse().ok()?;
+    let day: u32 = parts.next()?.parse().ok()?;
+    let year: u32 = parts.next()?.parse().ok()?;
+    if parts.next().is_some() || !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    Some(format!("{year:04}-{month:02}-{day:02}"))
+}
+
+/// Format the BIOS version and release date for display, degrading gracefully
+/// when either half is missing. The date is normalised to ISO 8601.
+pub fn format_bios(info: &DmiInfo) -> String {
+    let date = to_iso_date(&info.bios_date).unwrap_or_else(|| info.bios_date.clone());
+
+    match (info.bios_version.as_str(), date.as_str()) {
+        ("", "") => "Unknown".to_string(),
+        (version, "") => version.to_string(),
+        ("", date) => date.to_string(),
+        (version, date) => format!("{version} · {date}"),
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/dmi_tests.rs"]
+mod tests;

--- a/src/backend/tests/dmi_tests.rs
+++ b/src/backend/tests/dmi_tests.rs
@@ -1,0 +1,148 @@
+use super::*;
+
+// ------------------------------------------------------------------------
+// sanitize_dmi_value Tests
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_sanitize_dmi_value_normal() {
+    assert_eq!(sanitize_dmi_value("GA403UV.318"), "GA403UV.318");
+}
+
+#[test]
+fn test_sanitize_dmi_value_trims_whitespace() {
+    assert_eq!(sanitize_dmi_value("  1.P8 \n"), "1.P8");
+}
+
+#[test]
+fn test_sanitize_dmi_value_placeholders() {
+    for placeholder in [
+        "Default string",
+        "To Be Filled By O.E.M.",
+        "System Serial Number",
+        "Not Specified",
+        "Not Applicable",
+        "None",
+        "Unknown",
+        "N/A",
+    ] {
+        assert_eq!(
+            sanitize_dmi_value(placeholder),
+            "",
+            "expected {placeholder} to be treated as empty"
+        );
+    }
+}
+
+#[test]
+fn test_sanitize_dmi_value_placeholder_case_insensitive() {
+    assert_eq!(sanitize_dmi_value("DEFAULT STRING\n"), "");
+}
+
+#[test]
+fn test_sanitize_dmi_value_empty() {
+    assert_eq!(sanitize_dmi_value(""), "");
+    assert_eq!(sanitize_dmi_value("   \n"), "");
+}
+
+// ------------------------------------------------------------------------
+// format_bios Tests
+// ------------------------------------------------------------------------
+
+fn bios_info(version: &str, date: &str) -> DmiInfo {
+    DmiInfo {
+        bios_version: version.to_string(),
+        bios_date: date.to_string(),
+        ..DmiInfo::default()
+    }
+}
+
+#[test]
+fn test_format_bios_version_and_date() {
+    assert_eq!(
+        format_bios(&bios_info("1.P8", "03/17/2026")),
+        "1.P8 · 2026-03-17"
+    );
+}
+
+#[test]
+fn test_format_bios_version_only() {
+    assert_eq!(format_bios(&bios_info("1.P8", "")), "1.P8");
+}
+
+#[test]
+fn test_format_bios_date_only() {
+    assert_eq!(format_bios(&bios_info("", "03/17/2026")), "2026-03-17");
+}
+
+#[test]
+fn test_format_bios_neither() {
+    assert_eq!(format_bios(&bios_info("", "")), "Unknown");
+}
+
+#[test]
+fn test_format_bios_keeps_unparsable_date() {
+    assert_eq!(
+        format_bios(&bios_info("1.P8", "17.03.2026")),
+        "1.P8 · 17.03.2026"
+    );
+}
+
+// ------------------------------------------------------------------------
+// to_iso_date Tests
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_to_iso_date_smbios_format() {
+    assert_eq!(to_iso_date("07/02/2026").as_deref(), Some("2026-07-02"));
+}
+
+#[test]
+fn test_to_iso_date_pads_single_digits() {
+    assert_eq!(to_iso_date("7/2/2026").as_deref(), Some("2026-07-02"));
+}
+
+#[test]
+fn test_to_iso_date_rejects_out_of_range() {
+    assert_eq!(to_iso_date("13/02/2026"), None);
+    assert_eq!(to_iso_date("07/32/2026"), None);
+}
+
+#[test]
+fn test_to_iso_date_rejects_other_formats() {
+    assert_eq!(to_iso_date("17.03.2026"), None);
+    assert_eq!(to_iso_date("2026-03-17"), None);
+    assert_eq!(to_iso_date("07/02/2026/1"), None);
+    assert_eq!(to_iso_date(""), None);
+}
+
+// ------------------------------------------------------------------------
+// interpret_pkexec_failure Tests
+// ------------------------------------------------------------------------
+
+#[test]
+fn test_interpret_pkexec_failure_not_authorized() {
+    let message = interpret_pkexec_failure(Some(126)).to_string();
+    assert!(message.contains("Authorization"), "got: {message}");
+}
+
+#[test]
+fn test_interpret_pkexec_failure_missing_pkexec() {
+    let message = interpret_pkexec_failure(Some(127)).to_string();
+    assert!(
+        message.contains("pkexec is not available"),
+        "got: {message}"
+    );
+}
+
+#[test]
+fn test_interpret_pkexec_failure_other_code() {
+    let message = interpret_pkexec_failure(Some(1)).to_string();
+    assert!(message.contains("code 1"), "got: {message}");
+}
+
+#[test]
+fn test_interpret_pkexec_failure_signal() {
+    let message = interpret_pkexec_failure(None).to_string();
+    assert!(message.contains("signal"), "got: {message}");
+}

--- a/src/backend/types.rs
+++ b/src/backend/types.rs
@@ -478,6 +478,17 @@ pub struct SystemInfo {
     pub board_name: String,
 }
 
+/// World-readable DMI/SMBIOS fields from `/sys/class/dmi/id`.
+///
+/// Empty values mean the field was unreadable or held OEM placeholder text.
+#[derive(Debug, Clone, Default)]
+pub struct DmiInfo {
+    pub bios_version: String,
+    pub bios_date: String,
+    pub bios_vendor: String,
+    pub board_vendor: String,
+}
+
 #[cfg(test)]
 #[path = "tests/types_tests.rs"]
 mod tests;

--- a/src/ui/pages/about.rs
+++ b/src/ui/pages/about.rs
@@ -1,4 +1,5 @@
 use adw::prelude::*;
+use gtk4::gio;
 use gtk4::glib;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
@@ -7,6 +8,13 @@ use std::cell::RefCell;
 
 use crate::backend;
 use crate::ui::Refreshable;
+
+/// Placeholder shown for the serial number until the user reveals it.
+const SERIAL_HIDDEN: &str = "[ Hidden ]";
+/// Shown while the polkit prompt is open.
+const SERIAL_PENDING: &str = "Requesting permission...";
+/// Shown when the firmware has no serial to reveal.
+const SERIAL_MISSING: &str = "Not set";
 
 mod imp {
     use super::*;
@@ -82,6 +90,17 @@ impl AboutPage {
             .subtitle("Loading...")
             .build();
 
+        // DMI values are static for the boot, so they are read once here rather
+        // than on every refresh.
+        let dmi = backend::get_dmi_info();
+
+        let board_vendor_row = adw::ActionRow::builder()
+            .title("Board Vendor")
+            .subtitle(Self::or_unknown(&dmi.board_vendor))
+            .build();
+
+        let serial_row = Self::build_serial_row();
+
         let asusctl_row = adw::ActionRow::builder()
             .title("asusctl Version")
             .subtitle("Loading...")
@@ -99,6 +118,8 @@ impl AboutPage {
 
         laptop_group.add(&model_row);
         laptop_group.add(&driver_row);
+        laptop_group.add(&board_vendor_row);
+        laptop_group.add(&serial_row);
         laptop_group.add(&asusctl_row);
         laptop_group.add(&distro_row);
         laptop_group.add(&kernel_row);
@@ -109,6 +130,24 @@ impl AboutPage {
         imp.asusctl_row.replace(Some(asusctl_row));
 
         self.append(&laptop_group);
+
+        // Firmware group
+        let firmware_group = adw::PreferencesGroup::builder().title("Firmware").build();
+
+        let bios_row = adw::ActionRow::builder()
+            .title("BIOS")
+            .subtitle(backend::format_bios(dmi))
+            .build();
+
+        let bios_vendor_row = adw::ActionRow::builder()
+            .title("BIOS Vendor")
+            .subtitle(Self::or_unknown(&dmi.bios_vendor))
+            .build();
+
+        firmware_group.add(&bios_row);
+        firmware_group.add(&bios_vendor_row);
+
+        self.append(&firmware_group);
 
         // Service status group
         let status_group = adw::PreferencesGroup::builder()
@@ -126,6 +165,73 @@ impl AboutPage {
 
         self.append(&status_group);
         self.append(&features_group);
+    }
+
+    /// Fall back to "Unknown" for DMI fields the firmware left empty.
+    fn or_unknown(value: &str) -> &str {
+        if value.is_empty() { "Unknown" } else { value }
+    }
+
+    /// Build the serial number row. The value stays hidden until the user asks
+    /// for it, because `/sys/class/dmi/id/product_serial` is root-only and
+    /// reading it triggers a polkit prompt.
+    fn build_serial_row() -> adw::ActionRow {
+        let row = adw::ActionRow::builder()
+            .title("Serial Number")
+            .subtitle(SERIAL_HIDDEN)
+            .build();
+
+        let button = gtk4::Button::builder()
+            .label("Reveal")
+            .valign(gtk4::Align::Center)
+            .css_classes(["flat"])
+            .build();
+
+        let row_weak = row.downgrade();
+        button.connect_clicked(move |button| {
+            let Some(row) = row_weak.upgrade() else {
+                return;
+            };
+
+            button.set_sensitive(false);
+            row.set_subtitle(SERIAL_PENDING);
+
+            // pkexec blocks until the polkit dialog is answered, so it must not
+            // run on the main loop.
+            let row_weak = row.downgrade();
+            let button_weak = button.downgrade();
+            glib::spawn_future_local(async move {
+                let result = gio::spawn_blocking(backend::read_serial_number).await;
+
+                let Some(row) = row_weak.upgrade() else {
+                    return;
+                };
+
+                let error = match result {
+                    Ok(Ok(serial)) => {
+                        // A firmware without a serial is a final answer, so the
+                        // button goes away either way.
+                        row.set_subtitle(serial.as_deref().unwrap_or(SERIAL_MISSING));
+                        if let Some(button) = button_weak.upgrade() {
+                            button.set_visible(false);
+                        }
+                        return;
+                    }
+                    Ok(Err(e)) => e.to_string(),
+                    Err(_) => "the reading thread panicked".to_string(),
+                };
+
+                // Recoverable: the user can dismiss a polkit prompt and retry.
+                log::warn!("Failed to read serial number: {error}");
+                row.set_subtitle(SERIAL_HIDDEN);
+                if let Some(button) = button_weak.upgrade() {
+                    button.set_sensitive(true);
+                }
+            });
+        });
+
+        row.add_suffix(&button);
+        row
     }
 
     /// Refresh/reload all data on this page

--- a/src/ui/pages/about.rs
+++ b/src/ui/pages/about.rs
@@ -5,6 +5,7 @@ use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use libadwaita as adw;
 use std::cell::RefCell;
+use std::time::Duration;
 
 use crate::backend;
 use crate::ui::Refreshable;
@@ -15,6 +16,10 @@ const SERIAL_HIDDEN: &str = "[ Hidden ]";
 const SERIAL_PENDING: &str = "Requesting permission...";
 /// Shown when the firmware has no serial to reveal.
 const SERIAL_MISSING: &str = "Not set";
+const COPY_ICON: &str = "edit-copy-symbolic";
+const COPY_DONE_ICON: &str = "object-select-symbolic";
+/// How long the copy button shows the checkmark before reverting.
+const COPY_FEEDBACK: Duration = Duration::from_secs(2);
 
 mod imp {
     use super::*;
@@ -187,6 +192,16 @@ impl AboutPage {
             .css_classes(["flat"])
             .build();
 
+        // Only useful once a serial is on screen, so it starts hidden.
+        let copy_button = gtk4::Button::builder()
+            .icon_name(COPY_ICON)
+            .tooltip_text("Copy to clipboard")
+            .valign(gtk4::Align::Center)
+            .visible(false)
+            .css_classes(["flat"])
+            .build();
+
+        let copy_weak = copy_button.downgrade();
         let row_weak = row.downgrade();
         button.connect_clicked(move |button| {
             let Some(row) = row_weak.upgrade() else {
@@ -200,6 +215,7 @@ impl AboutPage {
             // run on the main loop.
             let row_weak = row.downgrade();
             let button_weak = button.downgrade();
+            let copy_weak = copy_weak.clone();
             glib::spawn_future_local(async move {
                 let result = gio::spawn_blocking(backend::read_serial_number).await;
 
@@ -210,10 +226,13 @@ impl AboutPage {
                 let error = match result {
                     Ok(Ok(serial)) => {
                         // A firmware without a serial is a final answer, so the
-                        // button goes away either way.
+                        // reveal button goes away either way.
                         row.set_subtitle(serial.as_deref().unwrap_or(SERIAL_MISSING));
                         if let Some(button) = button_weak.upgrade() {
                             button.set_visible(false);
+                        }
+                        if let (Some(serial), Some(copy_button)) = (serial, copy_weak.upgrade()) {
+                            Self::arm_copy_button(&copy_button, serial);
                         }
                         return;
                     }
@@ -230,8 +249,28 @@ impl AboutPage {
             });
         });
 
+        row.add_suffix(&copy_button);
         row.add_suffix(&button);
         row
+    }
+
+    /// Wire the copy button to the revealed serial and show it.
+    ///
+    /// The icon briefly turns into a checkmark as the only available feedback —
+    /// this app has no toast overlay.
+    fn arm_copy_button(copy_button: &gtk4::Button, serial: String) {
+        copy_button.connect_clicked(move |copy_button| {
+            copy_button.clipboard().set_text(&serial);
+            copy_button.set_icon_name(COPY_DONE_ICON);
+
+            let copy_weak = copy_button.downgrade();
+            glib::timeout_add_local_once(COPY_FEEDBACK, move || {
+                if let Some(copy_button) = copy_weak.upgrade() {
+                    copy_button.set_icon_name(COPY_ICON);
+                }
+            });
+        });
+        copy_button.set_visible(true);
     }
 
     /// Refresh/reload all data on this page


### PR DESCRIPTION
## Summary

The About page only showed what `asusctl info` reports plus distro and kernel. It now also surfaces the machine's own firmware identity, read straight from `/sys/class/dmi/id`.

- New `backend::dmi` module reading BIOS version/date/vendor and board vendor, with OEM placeholder text (`Default string`, `To Be Filled By O.E.M.`, …) normalised to empty so the UI shows "Unknown" instead of noise.
- BIOS release date converted from SMBIOS `MM/DD/YYYY` to ISO `YYYY-MM-DD`, shown as `1.R2 · 2026-07-02`.
- Serial number stays `[ Hidden ]` behind a Reveal button — `product_serial` is root-only, so it is read via `pkexec` (through `flatpak-spawn --host` in the sandbox) on a worker thread, keeping the window responsive while the polkit dialog is open. A refused prompt restores the hidden state; a firmware with no serial shows "Not set".
- A revealed serial gets a copy-to-clipboard button that confirms with a checkmark for two seconds.
- 18 unit tests over the pure helpers. Verified on an MSI MS-7D75 (placeholder-serial board) — no Flatpak manifest change needed, `--talk-name=org.freedesktop.Flatpak` already covers it.

Closes #75