### PR TITLE
chore: flatpak build hygiene and asusd service detection

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -29,3 +29,14 @@ jobs:
                   bundle: asusctl-gui.flatpak
                   branch: stable
                   upload-artifact: true
+
+            # Advisory only: these still flag the known sandbox hole
+            # (--talk-name=org.freedesktop.Flatpak) and the missing AppStream
+            # screenshots. Make them blocking once both are addressed.
+            - name: Lint Flatpak manifest
+              continue-on-error: true
+              run: flatpak-builder-lint manifest com.github.bl4ckspell7.asusctl-gui.yml
+
+            - name: Lint Flatpak repo
+              continue-on-error: true
+              run: flatpak-builder-lint repo repo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ env_logger = "0.11.11"
 
 [build-dependencies]
 glib-build-tools = "0.22.8"
+
+[profile.release]
+strip = true
+lto = "thin"

--- a/com.github.bl4ckspell7.asusctl-gui.yml
+++ b/com.github.bl4ckspell7.asusctl-gui.yml
@@ -40,7 +40,17 @@ modules:
       # GSettings schema
       - install -Dm0644 resources/${FLATPAK_ID}.gschema.xml ${FLATPAK_DEST}/share/glib-2.0/schemas/${FLATPAK_ID}.gschema.xml
       - glib-compile-schemas ${FLATPAK_DEST}/share/glib-2.0/schemas/
+      # Validate the installed metadata
+      - desktop-file-validate ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - appstreamcli validate --no-net ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
     sources:
       - type: dir
         path: .
+        # flatpak-builder ignores .gitignore, so build artefacts would be copied
+        skip:
+          - target
+          - .git
+          - .flatpak-builder
+          - builddir
+          - repo
       - cargo-sources.json

--- a/src/backend/dbus.rs
+++ b/src/backend/dbus.rs
@@ -61,8 +61,10 @@ pub fn run_asusctl(args: &[&str]) -> Result<String> {
 /// Classify an asusctl invocation's result. Separated from process spawning so
 /// the logic is unit-testable.
 ///
-/// - stderr mentioning the service / a refused connection -> `ServiceNotRunning`
-///   (asusctl is present but `asusd` is unreachable).
+/// - failure whose stderr shows `asusd` is unreachable -> `ServiceNotRunning`
+///   (asusctl is present but the daemon is down). See
+///   [`stderr_reports_service_down`] — a bare mention of the daemon does not
+///   qualify, and a successful run is never reclassified.
 /// - non-zero exit with empty stdout -> `NotInstalled`. Under
 ///   `flatpak-spawn --host` a missing host `asusctl` exits 127 with empty
 ///   stdout (flatpak-spawn itself runs, so it is not caught as a NotFound
@@ -70,13 +72,63 @@ pub fn run_asusctl(args: &[&str]) -> Result<String> {
 ///   the empty-output failure is treated as missing.
 /// - otherwise -> stdout as-is.
 fn interpret_asusctl_output(success: bool, stdout: String, stderr: &str) -> Result<String> {
-    if stderr.contains("Connection refused") || stderr.contains("asusd") {
+    if !success && stderr_reports_service_down(stderr) {
         return Err(AsusctlError::ServiceNotRunning);
     }
     if !success && stdout.trim().is_empty() {
         return Err(AsusctlError::NotInstalled);
     }
     Ok(stdout)
+}
+
+/// Messages that mean the daemon is unreachable, whoever produced them.
+///
+/// The two bus implementations word an unowned name differently: dbus-daemon
+/// says "was not provided by any .service files", dbus-broker (the Arch/Fedora
+/// default) says "is not activatable". The last two entries are asusctl's own
+/// prose, which it prints instead of the raw D-Bus error.
+const SERVICE_DOWN_MARKERS: &[&str] = &[
+    "connection refused",
+    "was not provided by any .service files",
+    "is not activatable",
+    "was not owned by anyone",
+    "org.freedesktop.dbus.error.serviceunknown",
+    "name has no owner",
+    "failed to connect to bus",
+    "could not get asusd version",
+    "asusd.service running",
+];
+
+/// Failure verbs that only mean "service down" when paired with `asusd`.
+const CONNECT_FAILURE_VERBS: &[&str] = &[
+    "failed to connect",
+    "could not connect",
+    "unable to connect",
+    "cannot connect",
+    "not running",
+];
+
+/// True when stderr shows `asusd` itself is unreachable, as opposed to a
+/// request the live daemon rejected.
+///
+/// A bare mention of "asusd" is not enough — warnings routinely name the daemon
+/// while it is running fine. Likewise `No such property` / `no such interface`
+/// come back from a *live* service that simply lacks that member, so they are
+/// deliberately not matched here.
+fn stderr_reports_service_down(stderr: &str) -> bool {
+    let lowered = stderr.to_lowercase();
+
+    if SERVICE_DOWN_MARKERS
+        .iter()
+        .any(|marker| lowered.contains(marker))
+    {
+        return true;
+    }
+
+    lowered.contains("asusd")
+        && CONNECT_FAILURE_VERBS
+            .iter()
+            .any(|verb| lowered.contains(verb))
 }
 
 // ============================================================================
@@ -99,7 +151,7 @@ pub fn read_dbus_property_at(path: &str, interface: &str, property: &str) -> Res
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("No such") || stderr.contains("not found") {
+        if stderr_reports_service_down(&stderr) {
             return Err(AsusctlError::ServiceNotRunning);
         }
         return Err(AsusctlError::CommandFailed(stderr.to_string()));

--- a/src/backend/tests/dbus_tests.rs
+++ b/src/backend/tests/dbus_tests.rs
@@ -44,3 +44,92 @@ fn success_returns_stdout() {
     let result = interpret_asusctl_output(true, "ok".to_string(), "");
     assert_eq!(result.unwrap(), "ok");
 }
+
+#[test]
+fn success_with_asusd_in_stderr_returns_stdout() {
+    // A successful run is never reclassified, however chatty its stderr.
+    let result = interpret_asusctl_output(
+        true,
+        "Active profile: Quiet".to_string(),
+        "warning: asusd config key 'foo' is deprecated",
+    );
+    assert_eq!(result.unwrap(), "Active profile: Quiet");
+}
+
+#[test]
+fn failure_with_asusd_warning_and_output_returns_stdout() {
+    // asusd is named but nothing says it is unreachable, and there is real
+    // output — this must not read as a dead service.
+    let result = interpret_asusctl_output(
+        false,
+        "Product family: ROG".to_string(),
+        "warning: asusd config key 'foo' is deprecated",
+    );
+    assert_eq!(result.unwrap(), "Product family: ROG");
+}
+
+#[test]
+fn transport_failures_are_service_down() {
+    for stderr in [
+        "Error: Connection refused",
+        // dbus-daemon wording for an unowned name...
+        "The name xyz.ljones.Asusd was not provided by any .service files",
+        // ...and dbus-broker's, which is what Arch and Fedora actually run.
+        "Failed to get property Brightness on interface xyz.ljones.Aura: The name is not activatable",
+        "org.freedesktop.DBus.Error.ServiceUnknown: no such service",
+        "Error: Name has no owner",
+        "Failed to connect to bus: No such file or directory",
+    ] {
+        assert!(
+            stderr_reports_service_down(stderr),
+            "expected service-down for: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn asusctl_own_daemon_down_prose_is_service_down() {
+    // Verbatim from asusctl 6.3.8 when asusd.service is stopped. It names no
+    // connect verb, so it has to be matched on its own.
+    let stderr = "Could not get asusd version: \nIs asusd.service running?";
+    assert!(stderr_reports_service_down(stderr));
+
+    // The whole point: this must not be mistaken for a missing binary.
+    let result = interpret_asusctl_output(false, String::new(), stderr);
+    assert!(matches!(result, Err(AsusctlError::ServiceNotRunning)));
+}
+
+#[test]
+fn asusd_with_failure_verb_is_service_down() {
+    for stderr in [
+        "failed to connect to asusd",
+        "Could not connect to asusd over dbus",
+        "Unable to connect to asusd",
+        "cannot connect to asusd",
+        "asusd is not running",
+    ] {
+        assert!(
+            stderr_reports_service_down(stderr),
+            "expected service-down for: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn live_service_errors_are_not_service_down() {
+    // These all come back from a service that is up but lacks the member, or
+    // merely mention the daemon in passing.
+    for stderr in [
+        "Failed to get property Brightness: No such property",
+        "Unknown property or interface",
+        "No such interface 'xyz.ljones.Slash'",
+        "No such object path '/xyz/ljones/aura/foo'",
+        "warning: asusd config key 'foo' is deprecated",
+        "asusd version 6.1.4",
+    ] {
+        assert!(
+            !stderr_reports_service_down(stderr),
+            "expected NOT service-down for: {stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Four low-risk fixes from a manifest review.

- `skip:` on the `dir` source — `flatpak-builder` ignores `.gitignore`, so the
  2.3 GB `target/` tree was copied into every build
- `desktop-file-validate` + `appstreamcli validate` in `build-commands`
- advisory `flatpak-builder-lint` in CI, still flagging the
  `org.freedesktop.Flatpak` sandbox hole and missing screenshots
- `[profile.release] strip + lto` — 2.8M → 1.9M
- one shared stderr classifier for `interpret_asusctl_output` and
  `read_dbus_property_at`, covering dbus-broker wording and asusctl's
  "Is asusd.service running?"

Full `flatpak-builder` run green in 52s, 100 tests pass, `zizmor` clean.