### PR TITLE
feat(ui): show backend write failures in toasts

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -29,6 +29,8 @@ mod slash;
 mod system;
 mod types;
 
+pub(crate) use error::AsusctlError;
+
 // Re-export types actually used by UI
 pub use types::{
     AuraDirection, AuraMode, AuraSpeed, KeyboardBrightness, PowerProfile, SlashMode,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,12 +1,15 @@
 mod pages;
 mod preferences_dialog;
 mod theme_switcher;
+mod toast;
 mod window;
 
 pub use pages::{AboutPage, AuraPage, PowerPage, SlashPage};
 pub use preferences_dialog::PreferencesDialog;
 pub use theme_switcher::ThemeSwitcher;
 pub use window::AsusctlGuiWindow;
+
+pub(crate) use toast::show_backend_error;
 
 use std::fmt;
 

--- a/src/ui/pages/about.rs
+++ b/src/ui/pages/about.rs
@@ -256,8 +256,8 @@ impl AboutPage {
 
     /// Wire the copy button to the revealed serial and show it.
     ///
-    /// The icon briefly turns into a checkmark as the only available feedback —
-    /// this app has no toast overlay.
+    /// The icon briefly turns into a checkmark to confirm the copy without
+    /// adding a success toast.
     fn arm_copy_button(copy_button: &gtk4::Button, serial: String) {
         copy_button.connect_clicked(move |copy_button| {
             copy_button.clipboard().set_text(&serial);

--- a/src/ui/pages/aura.rs
+++ b/src/ui/pages/aura.rs
@@ -29,6 +29,7 @@ mod imp {
         pub zone_dropdown: RefCell<Option<gtk4::DropDown>>,
         pub color_group: RefCell<Option<adw::PreferencesGroup>>,
         pub selected_mode: RefCell<AuraMode>,
+        pub confirmed_mode: Cell<AuraMode>,
         pub last_successful_zone: Cell<u32>,
         pub refreshing: RefCell<bool>,
     }
@@ -97,6 +98,9 @@ impl AuraPage {
         } else {
             features.aura_modes.clone()
         };
+        let initial_mode = supported_modes.first().copied().unwrap_or_default();
+        *imp.selected_mode.borrow_mut() = initial_mode;
+        imp.confirmed_mode.set(initial_mode);
         let supported_zones: Vec<String> = features.aura_zones.clone();
 
         // Page title
@@ -489,7 +493,10 @@ impl AuraPage {
             direction,
             zone.as_deref(),
         ) {
-            Ok(()) => imp.last_successful_zone.set(zone_index),
+            Ok(()) => {
+                imp.confirmed_mode.set(mode);
+                imp.last_successful_zone.set(zone_index);
+            }
             Err(e) => {
                 log::error!("Failed to set aura mode: {e}");
                 show_backend_error(self, "Couldn’t change Aura lighting", &e);
@@ -552,6 +559,7 @@ impl AuraPage {
                     combo.set_selected(index as u32);
                 }
                 *imp.selected_mode.borrow_mut() = mode;
+                imp.confirmed_mode.set(mode);
             }
         }
 
@@ -626,8 +634,29 @@ impl AuraPage {
             ),
             Err(e) => {
                 log::error!("Failed to reconcile Aura lighting after write failure: {e}");
+                self.restore_confirmed_mode();
             }
         }
+    }
+
+    fn restore_confirmed_mode(&self) {
+        let imp = self.imp();
+        let mode = imp.confirmed_mode.get();
+        *imp.refreshing.borrow_mut() = true;
+
+        {
+            let modes = imp.supported_modes.borrow();
+            if let Some(index) = modes.iter().position(|supported| *supported == mode) {
+                if let Some(combo) = imp.mode_combo.borrow().as_ref() {
+                    let _guard = combo.freeze_notify();
+                    combo.set_selected(index as u32);
+                }
+                *imp.selected_mode.borrow_mut() = mode;
+            }
+        }
+
+        self.update_mode_visibility();
+        *imp.refreshing.borrow_mut() = false;
     }
 
     /// Refresh/reload all data on this page

--- a/src/ui/pages/aura.rs
+++ b/src/ui/pages/aura.rs
@@ -4,10 +4,10 @@ use gtk4::glib::prelude::ObjectExt;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use libadwaita as adw;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use crate::backend::{self, AuraDirection, AuraMode, AuraSpeed, KeyboardBrightness};
-use crate::ui::Refreshable;
+use crate::ui::{Refreshable, show_backend_error};
 
 mod imp {
     use super::*;
@@ -29,6 +29,7 @@ mod imp {
         pub zone_dropdown: RefCell<Option<gtk4::DropDown>>,
         pub color_group: RefCell<Option<adw::PreferencesGroup>>,
         pub selected_mode: RefCell<AuraMode>,
+        pub last_successful_zone: Cell<u32>,
         pub refreshing: RefCell<bool>,
     }
 
@@ -142,6 +143,8 @@ impl AuraPage {
                 if button.is_active() {
                     if let Err(e) = backend::set_keyboard_brightness(level_clone) {
                         log::error!("Failed to set brightness: {e}");
+                        show_backend_error(&this, "Couldn’t change keyboard brightness", &e);
+                        this.reconcile_brightness_after_write_failure();
                     }
                 }
             });
@@ -213,9 +216,6 @@ impl AuraPage {
             let modes = supported_modes.clone();
             let help_map = mode_help.clone();
             mode_combo.connect_selected_notify(move |combo| {
-                if *this.imp().refreshing.borrow() {
-                    return;
-                }
                 let idx = combo.selected() as usize;
                 if let Some(&mode) = modes.get(idx) {
                     *this.imp().selected_mode.borrow_mut() = mode;
@@ -223,7 +223,9 @@ impl AuraPage {
                         info_popover_label.set_text(help);
                     }
                     this.update_mode_visibility();
-                    this.apply_aura();
+                    if !*this.imp().refreshing.borrow() {
+                        this.apply_aura();
+                    }
                 }
             });
         }
@@ -464,18 +466,22 @@ impl AuraPage {
             .find(|(btn, _)| btn.is_active())
             .map(|(_, d)| *d);
 
-        let zone = imp.zone_dropdown.borrow().as_ref().and_then(|dd| {
-            let selected = dd.selected();
-            if selected == 0 {
-                None // "Default" = no zone arg
+        let (zone_index, zone) = if let Some(dropdown) = imp.zone_dropdown.borrow().as_ref() {
+            let selected = dropdown.selected();
+            let zone = if selected == 0 {
+                None
             } else {
-                dd.selected_item()
+                dropdown
+                    .selected_item()
                     .and_downcast::<gtk4::StringObject>()
                     .map(|obj| obj.string().to_string())
-            }
-        });
+            };
+            (selected, zone)
+        } else {
+            (0, None)
+        };
 
-        if let Err(e) = backend::set_aura_mode(
+        match backend::set_aura_mode(
             mode,
             colour.as_deref(),
             colour2.as_deref(),
@@ -483,7 +489,144 @@ impl AuraPage {
             direction,
             zone.as_deref(),
         ) {
-            log::error!("Failed to set aura mode: {e}");
+            Ok(()) => imp.last_successful_zone.set(zone_index),
+            Err(e) => {
+                log::error!("Failed to set aura mode: {e}");
+                show_backend_error(self, "Couldn’t change Aura lighting", &e);
+                self.reconcile_aura_after_write_failure();
+            }
+        }
+    }
+
+    fn apply_keyboard_brightness(&self, brightness: KeyboardBrightness) {
+        let imp = self.imp();
+        *imp.refreshing.borrow_mut() = true;
+
+        {
+            let buttons = imp.brightness_buttons.borrow();
+            let index = match brightness {
+                KeyboardBrightness::Off => 0,
+                KeyboardBrightness::Low => 1,
+                KeyboardBrightness::Med => 2,
+                KeyboardBrightness::High => 3,
+            };
+
+            let _guards: Vec<_> = buttons
+                .iter()
+                .map(|button| button.freeze_notify())
+                .collect();
+            if let Some(button) = buttons.get(index) {
+                button.set_active(true);
+            }
+        }
+
+        *imp.refreshing.borrow_mut() = false;
+    }
+
+    fn reconcile_brightness_after_write_failure(&self) {
+        match backend::get_keyboard_brightness_dbus() {
+            Ok(brightness) => self.apply_keyboard_brightness(brightness),
+            Err(e) => {
+                log::error!("Failed to reconcile keyboard brightness after write failure: {e}");
+            }
+        }
+    }
+
+    fn apply_aura_mode_state(
+        &self,
+        mode: AuraMode,
+        speed: AuraSpeed,
+        direction: AuraDirection,
+        color1: (u8, u8, u8),
+        color2: (u8, u8, u8),
+        zone_index: Option<u32>,
+    ) {
+        let imp = self.imp();
+        *imp.refreshing.borrow_mut() = true;
+
+        {
+            let modes = imp.supported_modes.borrow();
+            if let Some(index) = modes.iter().position(|supported| *supported == mode) {
+                if let Some(combo) = imp.mode_combo.borrow().as_ref() {
+                    let _guard = combo.freeze_notify();
+                    combo.set_selected(index as u32);
+                }
+                *imp.selected_mode.borrow_mut() = mode;
+            }
+        }
+
+        {
+            let speed_buttons = imp.speed_buttons.borrow();
+            let _guards: Vec<_> = speed_buttons
+                .iter()
+                .map(|(button, _)| button.freeze_notify())
+                .collect();
+            for (button, button_speed) in speed_buttons.iter() {
+                if *button_speed == speed {
+                    button.set_active(true);
+                    break;
+                }
+            }
+        }
+
+        {
+            let direction_buttons = imp.direction_buttons.borrow();
+            let _guards: Vec<_> = direction_buttons
+                .iter()
+                .map(|(button, _)| button.freeze_notify())
+                .collect();
+            for (button, button_direction) in direction_buttons.iter() {
+                if *button_direction == direction {
+                    button.set_active(true);
+                    break;
+                }
+            }
+        }
+
+        if let Some(color_button) = imp.color_button.borrow().as_ref() {
+            let _guard = color_button.freeze_notify();
+            let (red, green, blue) = color1;
+            color_button.set_rgba(&gtk4::gdk::RGBA::new(
+                red as f32 / 255.0,
+                green as f32 / 255.0,
+                blue as f32 / 255.0,
+                1.0,
+            ));
+        }
+
+        if let Some(color_button) = imp.color2_button.borrow().as_ref() {
+            let _guard = color_button.freeze_notify();
+            let (red, green, blue) = color2;
+            color_button.set_rgba(&gtk4::gdk::RGBA::new(
+                red as f32 / 255.0,
+                green as f32 / 255.0,
+                blue as f32 / 255.0,
+                1.0,
+            ));
+        }
+
+        if let (Some(index), Some(dropdown)) = (zone_index, imp.zone_dropdown.borrow().as_ref()) {
+            let _guard = dropdown.freeze_notify();
+            dropdown.set_selected(index);
+        }
+
+        self.update_mode_visibility();
+        *imp.refreshing.borrow_mut() = false;
+    }
+
+    fn reconcile_aura_after_write_failure(&self) {
+        match backend::get_aura_mode_data_dbus() {
+            Ok(mode_data) => self.apply_aura_mode_state(
+                mode_data.mode,
+                mode_data.speed,
+                mode_data.direction,
+                mode_data.color1,
+                mode_data.color2,
+                Some(self.imp().last_successful_zone.get()),
+            ),
+            Err(e) => {
+                log::error!("Failed to reconcile Aura lighting after write failure: {e}");
+            }
         }
     }
 
@@ -495,26 +638,9 @@ impl AuraPage {
             return;
         }
 
-        *imp.refreshing.borrow_mut() = true;
-
         // Get current brightness via D-Bus and update buttons
         match backend::get_keyboard_brightness_dbus() {
-            Ok(current_brightness) => {
-                let buttons = imp.brightness_buttons.borrow();
-                let index = match current_brightness {
-                    KeyboardBrightness::Off => 0,
-                    KeyboardBrightness::Low => 1,
-                    KeyboardBrightness::Med => 2,
-                    KeyboardBrightness::High => 3,
-                };
-
-                // Freeze all buttons to prevent GTK state accounting issues
-                // Guards auto-call thaw_notify when dropped
-                let _guards: Vec<_> = buttons.iter().map(|btn| btn.freeze_notify()).collect();
-                if let Some(btn) = buttons.get(index) {
-                    btn.set_active(true);
-                }
-            }
+            Ok(current_brightness) => self.apply_keyboard_brightness(current_brightness),
             Err(e) => {
                 log::error!("Failed to get keyboard brightness: {e}");
             }
@@ -522,84 +648,18 @@ impl AuraPage {
 
         // Get full aura mode data via D-Bus and update all controls
         match backend::get_aura_mode_data_dbus() {
-            Ok(mode_data) => {
-                // Update mode combo
-                {
-                    let modes = imp.supported_modes.borrow();
-                    if let Some(idx) = modes.iter().position(|m| *m == mode_data.mode) {
-                        if let Some(combo) = imp.mode_combo.borrow().as_ref() {
-                            let _guard = combo.freeze_notify();
-                            combo.set_selected(idx as u32);
-                        }
-                        *imp.selected_mode.borrow_mut() = mode_data.mode;
-                    }
-                }
-
-                // Update speed buttons
-                {
-                    let speed_buttons = imp.speed_buttons.borrow();
-                    let _guards: Vec<_> = speed_buttons
-                        .iter()
-                        .map(|(btn, _)| btn.freeze_notify())
-                        .collect();
-                    for (btn, speed) in speed_buttons.iter() {
-                        if *speed == mode_data.speed {
-                            btn.set_active(true);
-                            break;
-                        }
-                    }
-                }
-
-                // Update direction buttons
-                {
-                    let direction_buttons = imp.direction_buttons.borrow();
-                    let _guards: Vec<_> = direction_buttons
-                        .iter()
-                        .map(|(btn, _)| btn.freeze_notify())
-                        .collect();
-                    for (btn, dir) in direction_buttons.iter() {
-                        if *dir == mode_data.direction {
-                            btn.set_active(true);
-                            break;
-                        }
-                    }
-                }
-
-                // Update primary color (guard prevents callback during set_rgba)
-                if let Some(color_btn) = imp.color_button.borrow().as_ref() {
-                    let _guard = color_btn.freeze_notify();
-                    let (r, g, b) = mode_data.color1;
-                    let rgba = gtk4::gdk::RGBA::new(
-                        r as f32 / 255.0,
-                        g as f32 / 255.0,
-                        b as f32 / 255.0,
-                        1.0,
-                    );
-                    color_btn.set_rgba(&rgba);
-                }
-
-                // Update secondary color
-                if let Some(color2_btn) = imp.color2_button.borrow().as_ref() {
-                    let _guard = color2_btn.freeze_notify();
-                    let (r, g, b) = mode_data.color2;
-                    let rgba = gtk4::gdk::RGBA::new(
-                        r as f32 / 255.0,
-                        g as f32 / 255.0,
-                        b as f32 / 255.0,
-                        1.0,
-                    );
-                    color2_btn.set_rgba(&rgba);
-                }
-
-                // Update visibility based on the current mode
-                self.update_mode_visibility();
-            }
+            Ok(mode_data) => self.apply_aura_mode_state(
+                mode_data.mode,
+                mode_data.speed,
+                mode_data.direction,
+                mode_data.color1,
+                mode_data.color2,
+                None,
+            ),
             Err(e) => {
                 log::error!("Failed to get aura mode data: {e}");
             }
         }
-
-        *imp.refreshing.borrow_mut() = false;
     }
 }
 

--- a/src/ui/pages/power.rs
+++ b/src/ui/pages/power.rs
@@ -7,7 +7,7 @@ use libadwaita as adw;
 use std::cell::RefCell;
 
 use crate::backend::{self, PowerProfile};
-use crate::ui::Refreshable;
+use crate::ui::{Refreshable, show_backend_error};
 
 mod imp {
     use super::*;
@@ -148,6 +148,8 @@ impl PowerPage {
                 if button.is_active() {
                     if let Err(e) = backend::set_profile(profile_clone) {
                         log::error!("Failed to set profile: {e}");
+                        show_backend_error(&this, "Couldn’t change the power profile", &e);
+                        this.reconcile_profiles_after_write_failure();
                     }
                 }
             });
@@ -193,6 +195,8 @@ impl PowerPage {
                 };
                 if let Err(e) = backend::set_profile_ac(profile) {
                     log::error!("Failed to set AC profile: {e}");
+                    show_backend_error(&this, "Couldn’t change the AC power profile", &e);
+                    this.reconcile_profiles_after_write_failure();
                 }
             });
         }
@@ -231,6 +235,8 @@ impl PowerPage {
                 };
                 if let Err(e) = backend::set_profile_battery(profile) {
                     log::error!("Failed to set battery profile: {e}");
+                    show_backend_error(&this, "Couldn’t change the battery power profile", &e);
+                    this.reconcile_profiles_after_write_failure();
                 }
             });
         }
@@ -269,6 +275,8 @@ impl PowerPage {
                     let value = scale.value() as u8;
                     if let Err(e) = backend::set_charge_limit(value) {
                         log::error!("Failed to set charge limit: {e}");
+                        show_backend_error(&this, "Couldn’t change the charge limit", &e);
+                        this.reconcile_charge_limit_after_write_failure();
                     }
                 });
             }
@@ -281,6 +289,82 @@ impl PowerPage {
         }
     }
 
+    fn apply_profile_state(
+        &self,
+        active: PowerProfile,
+        on_ac: PowerProfile,
+        on_battery: PowerProfile,
+    ) {
+        let imp = self.imp();
+        *imp.refreshing.borrow_mut() = true;
+
+        {
+            let radios = imp.profile_radios.borrow();
+            let index = match active {
+                PowerProfile::Quiet => 0,
+                PowerProfile::Balanced => 1,
+                PowerProfile::Performance => 2,
+            };
+
+            let _guards: Vec<_> = radios.iter().map(|radio| radio.freeze_notify()).collect();
+            if let Some(radio) = radios.get(index) {
+                radio.set_active(true);
+            }
+        }
+
+        if let Some(combo) = imp.ac_combo.borrow().as_ref() {
+            let _guard = combo.freeze_notify();
+            let index = match on_ac {
+                PowerProfile::Quiet => 0,
+                PowerProfile::Balanced => 1,
+                PowerProfile::Performance => 2,
+            };
+            combo.set_selected(index);
+        }
+
+        if let Some(combo) = imp.battery_combo.borrow().as_ref() {
+            let _guard = combo.freeze_notify();
+            let index = match on_battery {
+                PowerProfile::Quiet => 0,
+                PowerProfile::Balanced => 1,
+                PowerProfile::Performance => 2,
+            };
+            combo.set_selected(index);
+        }
+
+        *imp.refreshing.borrow_mut() = false;
+    }
+
+    fn reconcile_profiles_after_write_failure(&self) {
+        match backend::get_profile_state() {
+            Ok(state) => self.apply_profile_state(state.active, state.on_ac, state.on_battery),
+            Err(e) => {
+                log::error!("Failed to reconcile profile state after write failure: {e}");
+            }
+        }
+    }
+
+    fn apply_charge_limit(&self, limit: u8) {
+        let imp = self.imp();
+        *imp.refreshing.borrow_mut() = true;
+
+        if let Some(scale) = imp.charge_scale.borrow().as_ref() {
+            let _guard = scale.freeze_notify();
+            scale.set_value(limit as f64);
+        }
+
+        *imp.refreshing.borrow_mut() = false;
+    }
+
+    fn reconcile_charge_limit_after_write_failure(&self) {
+        match backend::get_charge_limit_dbus() {
+            Ok(limit) => self.apply_charge_limit(limit),
+            Err(e) => {
+                log::error!("Failed to reconcile charge limit after write failure: {e}");
+            }
+        }
+    }
+
     /// Refresh/reload all data on this page
     fn refresh_data(&self) {
         let imp = self.imp();
@@ -289,51 +373,9 @@ impl PowerPage {
             return;
         }
 
-        *imp.refreshing.borrow_mut() = true;
-
         // Get current profile state via CLI (more reliable mapping)
         match backend::get_profile_state() {
-            Ok(state) => {
-                // Update profile radios
-                {
-                    let radios = imp.profile_radios.borrow();
-                    let index = match state.active {
-                        PowerProfile::Quiet => 0,
-                        PowerProfile::Balanced => 1,
-                        PowerProfile::Performance => 2,
-                    };
-
-                    // Freeze all radios to prevent GTK state accounting issues
-                    // Guards auto-call thaw_notify when dropped
-                    let _guards: Vec<_> =
-                        radios.iter().map(|radio| radio.freeze_notify()).collect();
-                    if let Some(radio) = radios.get(index) {
-                        radio.set_active(true);
-                    }
-                }
-
-                // Set AC combo
-                if let Some(combo) = imp.ac_combo.borrow().as_ref() {
-                    let _guard = combo.freeze_notify();
-                    let ac_index = match state.on_ac {
-                        PowerProfile::Quiet => 0,
-                        PowerProfile::Balanced => 1,
-                        PowerProfile::Performance => 2,
-                    };
-                    combo.set_selected(ac_index);
-                }
-
-                // Set battery combo
-                if let Some(combo) = imp.battery_combo.borrow().as_ref() {
-                    let _guard = combo.freeze_notify();
-                    let bat_index = match state.on_battery {
-                        PowerProfile::Quiet => 0,
-                        PowerProfile::Balanced => 1,
-                        PowerProfile::Performance => 2,
-                    };
-                    combo.set_selected(bat_index);
-                }
-            }
+            Ok(state) => self.apply_profile_state(state.active, state.on_ac, state.on_battery),
             Err(e) => {
                 log::error!("Failed to get profile state: {e}");
             }
@@ -341,20 +383,13 @@ impl PowerPage {
 
         // Load charge limit via D-Bus (only if charge control is supported)
         if *imp.charge_control_available.borrow() {
-            if let Some(scale) = imp.charge_scale.borrow().as_ref() {
-                match backend::get_charge_limit_dbus() {
-                    Ok(limit) => {
-                        let _guard = scale.freeze_notify();
-                        scale.set_value(limit as f64);
-                    }
-                    Err(e) => {
-                        log::error!("Failed to get charge limit: {e}");
-                    }
+            match backend::get_charge_limit_dbus() {
+                Ok(limit) => self.apply_charge_limit(limit),
+                Err(e) => {
+                    log::error!("Failed to get charge limit: {e}");
                 }
             }
         }
-
-        *imp.refreshing.borrow_mut() = false;
     }
 }
 

--- a/src/ui/pages/slash.rs
+++ b/src/ui/pages/slash.rs
@@ -4,7 +4,7 @@ use gtk4::glib::prelude::ObjectExt;
 use gtk4::prelude::*;
 use gtk4::subclass::prelude::*;
 use libadwaita as adw;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use crate::backend::{self, AsusctlError, SlashMode};
 use crate::ui::{Refreshable, show_backend_error};
@@ -24,6 +24,7 @@ mod imp {
         pub show_on_sleep: RefCell<Option<adw::SwitchRow>>,
         pub show_on_battery: RefCell<Option<adw::SwitchRow>>,
         pub show_battery_warning: RefCell<Option<adw::SwitchRow>>,
+        pub confirmed_enabled: Cell<bool>,
         /// Flag to prevent signal handlers from firing during refresh
         pub refreshing: RefCell<bool>,
     }
@@ -152,10 +153,13 @@ impl SlashPage {
                     scale.set_sensitive(enabled);
                 }
 
-                if let Err(e) = result {
-                    log::error!("Failed to toggle slash: {e}");
-                    show_backend_error(&this, "Couldn’t change Slash lighting", &e);
-                    this.reconcile_enabled_after_write_failure();
+                match result {
+                    Ok(()) => this.imp().confirmed_enabled.set(enabled),
+                    Err(e) => {
+                        log::error!("Failed to toggle slash: {e}");
+                        show_backend_error(&this, "Couldn’t change Slash lighting", &e);
+                        this.reconcile_enabled_after_write_failure();
+                    }
                 }
             });
         }
@@ -397,6 +401,7 @@ impl SlashPage {
     fn apply_enabled_state(&self, enabled: bool) {
         let imp = self.imp();
         *imp.refreshing.borrow_mut() = true;
+        imp.confirmed_enabled.set(enabled);
 
         if let Some(switch) = imp.enable_switch.borrow().as_ref() {
             let _guard = switch.freeze_notify();
@@ -414,6 +419,7 @@ impl SlashPage {
             Ok(enabled) => self.apply_enabled_state(enabled),
             Err(e) => {
                 log::error!("Failed to reconcile Slash enabled state after write failure: {e}");
+                self.apply_enabled_state(self.imp().confirmed_enabled.get());
             }
         }
     }
@@ -573,11 +579,12 @@ impl SlashPage {
                 Ok(enabled) => {
                     let _guard = switch.freeze_notify();
                     switch.set_active(enabled);
+                    imp.confirmed_enabled.set(enabled);
                     enabled
                 }
                 Err(e) => {
                     log::error!("Failed to get slash enabled state: {e}");
-                    false
+                    imp.confirmed_enabled.get()
                 }
             }
         } else {

--- a/src/ui/pages/slash.rs
+++ b/src/ui/pages/slash.rs
@@ -6,8 +6,8 @@ use gtk4::subclass::prelude::*;
 use libadwaita as adw;
 use std::cell::RefCell;
 
-use crate::backend::{self, SlashMode};
-use crate::ui::Refreshable;
+use crate::backend::{self, AsusctlError, SlashMode};
+use crate::ui::{Refreshable, show_backend_error};
 
 mod imp {
     use super::*;
@@ -147,13 +147,15 @@ impl SlashPage {
                     backend::disable_slash()
                 };
 
-                if let Err(e) = result {
-                    log::error!("Failed to toggle slash: {e}");
-                }
-
-                // Enable/disable brightness slider based on slash state
+                // Keep slider sensitivity consistent with the optimistic switch state.
                 if let Some(scale) = this.imp().brightness_scale.borrow().as_ref() {
                     scale.set_sensitive(enabled);
+                }
+
+                if let Err(e) = result {
+                    log::error!("Failed to toggle slash: {e}");
+                    show_backend_error(&this, "Couldn’t change Slash lighting", &e);
+                    this.reconcile_enabled_after_write_failure();
                 }
             });
         }
@@ -188,6 +190,8 @@ impl SlashPage {
                 let value = scale.value() as u8;
                 if let Err(e) = backend::set_slash_brightness(value) {
                     log::error!("Failed to set slash brightness: {e}");
+                    show_backend_error(&this, "Couldn’t change Slash brightness", &e);
+                    this.reconcile_brightness_after_write_failure();
                 }
             });
         }
@@ -238,6 +242,8 @@ impl SlashPage {
 
                 if let Err(e) = backend::set_slash_mode(mode) {
                     log::error!("Failed to set slash mode: {e}");
+                    show_backend_error(&this, "Couldn’t change the Slash animation", &e);
+                    this.reconcile_mode_after_write_failure();
                 }
             });
         }
@@ -263,6 +269,8 @@ impl SlashPage {
                 let interval = combo.selected() as u8;
                 if let Err(e) = backend::set_slash_interval(interval) {
                     log::error!("Failed to set slash interval: {e}");
+                    show_backend_error(&this, "Couldn’t change the Slash animation speed", &e);
+                    this.reconcile_interval_after_write_failure();
                 }
             });
         }
@@ -290,6 +298,8 @@ impl SlashPage {
                 }
                 if let Err(e) = backend::set_slash_show_on_boot(switch.is_active()) {
                     log::error!("Failed to set show on boot: {e}");
+                    show_backend_error(&this, "Couldn’t change the Slash event settings", &e);
+                    this.reconcile_show_on_boot_after_write_failure();
                 }
             });
         }
@@ -309,6 +319,8 @@ impl SlashPage {
                 }
                 if let Err(e) = backend::set_slash_show_on_shutdown(switch.is_active()) {
                     log::error!("Failed to set show on shutdown: {e}");
+                    show_backend_error(&this, "Couldn’t change the Slash event settings", &e);
+                    this.reconcile_show_on_shutdown_after_write_failure();
                 }
             });
         }
@@ -328,6 +340,8 @@ impl SlashPage {
                 }
                 if let Err(e) = backend::set_slash_show_on_sleep(switch.is_active()) {
                     log::error!("Failed to set show on sleep: {e}");
+                    show_backend_error(&this, "Couldn’t change the Slash event settings", &e);
+                    this.reconcile_show_on_sleep_after_write_failure();
                 }
             });
         }
@@ -347,6 +361,8 @@ impl SlashPage {
                 }
                 if let Err(e) = backend::set_slash_show_on_battery(switch.is_active()) {
                     log::error!("Failed to set show on battery: {e}");
+                    show_backend_error(&this, "Couldn’t change the Slash event settings", &e);
+                    this.reconcile_show_on_battery_after_write_failure();
                 }
             });
         }
@@ -366,6 +382,8 @@ impl SlashPage {
                 }
                 if let Err(e) = backend::set_slash_show_battery_warning(switch.is_active()) {
                     log::error!("Failed to set show battery warning: {e}");
+                    show_backend_error(&this, "Couldn’t change the Slash event settings", &e);
+                    this.reconcile_battery_warning_after_write_failure();
                 }
             });
         }
@@ -374,6 +392,168 @@ impl SlashPage {
         events_group.add(&show_battery_warning);
 
         self.append(&events_group);
+    }
+
+    fn apply_enabled_state(&self, enabled: bool) {
+        let imp = self.imp();
+        *imp.refreshing.borrow_mut() = true;
+
+        if let Some(switch) = imp.enable_switch.borrow().as_ref() {
+            let _guard = switch.freeze_notify();
+            switch.set_active(enabled);
+        }
+        if let Some(scale) = imp.brightness_scale.borrow().as_ref() {
+            scale.set_sensitive(enabled);
+        }
+
+        *imp.refreshing.borrow_mut() = false;
+    }
+
+    fn reconcile_enabled_after_write_failure(&self) {
+        match backend::get_slash_enabled() {
+            Ok(enabled) => self.apply_enabled_state(enabled),
+            Err(e) => {
+                log::error!("Failed to reconcile Slash enabled state after write failure: {e}");
+            }
+        }
+    }
+
+    fn apply_brightness(&self, brightness: u8) {
+        let imp = self.imp();
+        *imp.refreshing.borrow_mut() = true;
+
+        if let Some(scale) = imp.brightness_scale.borrow().as_ref() {
+            let _guard = scale.freeze_notify();
+            scale.set_value(brightness as f64);
+        }
+
+        *imp.refreshing.borrow_mut() = false;
+    }
+
+    fn reconcile_brightness_after_write_failure(&self) {
+        match backend::get_slash_brightness() {
+            Ok(brightness) => self.apply_brightness(brightness),
+            Err(e) => {
+                log::error!("Failed to reconcile Slash brightness after write failure: {e}");
+            }
+        }
+    }
+
+    fn apply_mode(&self, mode: SlashMode) {
+        let imp = self.imp();
+        *imp.refreshing.borrow_mut() = true;
+
+        if let Some(combo) = imp.mode_combo.borrow().as_ref() {
+            let _guard = combo.freeze_notify();
+            combo.set_selected(slash_mode_index(mode));
+        }
+
+        *imp.refreshing.borrow_mut() = false;
+    }
+
+    fn reconcile_mode_after_write_failure(&self) {
+        match backend::get_slash_mode() {
+            Ok(mode) => self.apply_mode(mode),
+            Err(e) => {
+                log::error!("Failed to reconcile Slash mode after write failure: {e}");
+            }
+        }
+    }
+
+    fn apply_interval(&self, interval: u8) {
+        let imp = self.imp();
+        *imp.refreshing.borrow_mut() = true;
+
+        if let Some(combo) = imp.interval_combo.borrow().as_ref() {
+            let _guard = combo.freeze_notify();
+            combo.set_selected(interval as u32);
+        }
+
+        *imp.refreshing.borrow_mut() = false;
+    }
+
+    fn reconcile_interval_after_write_failure(&self) {
+        match backend::get_slash_interval() {
+            Ok(interval) => self.apply_interval(interval),
+            Err(e) => {
+                log::error!("Failed to reconcile Slash interval after write failure: {e}");
+            }
+        }
+    }
+
+    fn apply_event_switch(&self, switch: &adw::SwitchRow, value: bool) {
+        let imp = self.imp();
+        *imp.refreshing.borrow_mut() = true;
+
+        {
+            let _guard = switch.freeze_notify();
+            switch.set_active(value);
+        }
+
+        *imp.refreshing.borrow_mut() = false;
+    }
+
+    fn reconcile_event_switch(
+        &self,
+        result: Result<bool, AsusctlError>,
+        switch: Option<adw::SwitchRow>,
+        setting: &str,
+    ) {
+        match result {
+            Ok(value) => {
+                if let Some(switch) = switch {
+                    self.apply_event_switch(&switch, value);
+                }
+            }
+            Err(e) => {
+                log::error!("Failed to reconcile {setting} after write failure: {e}");
+            }
+        }
+    }
+
+    fn reconcile_show_on_boot_after_write_failure(&self) {
+        let switch = self.imp().show_on_boot.borrow().clone();
+        self.reconcile_event_switch(
+            backend::get_slash_show_on_boot(),
+            switch,
+            "Slash show-on-boot state",
+        );
+    }
+
+    fn reconcile_show_on_shutdown_after_write_failure(&self) {
+        let switch = self.imp().show_on_shutdown.borrow().clone();
+        self.reconcile_event_switch(
+            backend::get_slash_show_on_shutdown(),
+            switch,
+            "Slash show-on-shutdown state",
+        );
+    }
+
+    fn reconcile_show_on_sleep_after_write_failure(&self) {
+        let switch = self.imp().show_on_sleep.borrow().clone();
+        self.reconcile_event_switch(
+            backend::get_slash_show_on_sleep(),
+            switch,
+            "Slash show-on-sleep state",
+        );
+    }
+
+    fn reconcile_show_on_battery_after_write_failure(&self) {
+        let switch = self.imp().show_on_battery.borrow().clone();
+        self.reconcile_event_switch(
+            backend::get_slash_show_on_battery(),
+            switch,
+            "Slash show-on-battery state",
+        );
+    }
+
+    fn reconcile_battery_warning_after_write_failure(&self) {
+        let switch = self.imp().show_battery_warning.borrow().clone();
+        self.reconcile_event_switch(
+            backend::get_slash_show_battery_warning(),
+            switch,
+            "Slash battery-warning state",
+        );
     }
 
     /// Refresh/reload all data on this page
@@ -422,26 +602,8 @@ impl SlashPage {
         if let Some(combo) = imp.mode_combo.borrow().as_ref() {
             match backend::get_slash_mode() {
                 Ok(mode) => {
-                    let index = match mode {
-                        SlashMode::Static => 0,
-                        SlashMode::Bounce => 1,
-                        SlashMode::Slash => 2,
-                        SlashMode::Loading => 3,
-                        SlashMode::BitStream => 4,
-                        SlashMode::Transmission => 5,
-                        SlashMode::Flow => 6,
-                        SlashMode::Flux => 7,
-                        SlashMode::Phantom => 8,
-                        SlashMode::Spectrum => 9,
-                        SlashMode::Hazard => 10,
-                        SlashMode::Interfacing => 11,
-                        SlashMode::Ramp => 12,
-                        SlashMode::GameOver => 13,
-                        SlashMode::Start => 14,
-                        SlashMode::Buzzer => 15,
-                    };
                     let _guard = combo.freeze_notify();
-                    combo.set_selected(index);
+                    combo.set_selected(slash_mode_index(mode));
                 }
                 Err(e) => {
                     log::error!("Failed to get slash mode: {e}");
@@ -500,6 +662,27 @@ impl SlashPage {
 
         // Clear refreshing flag
         *imp.refreshing.borrow_mut() = false;
+    }
+}
+
+fn slash_mode_index(mode: SlashMode) -> u32 {
+    match mode {
+        SlashMode::Static => 0,
+        SlashMode::Bounce => 1,
+        SlashMode::Slash => 2,
+        SlashMode::Loading => 3,
+        SlashMode::BitStream => 4,
+        SlashMode::Transmission => 5,
+        SlashMode::Flow => 6,
+        SlashMode::Flux => 7,
+        SlashMode::Phantom => 8,
+        SlashMode::Spectrum => 9,
+        SlashMode::Hazard => 10,
+        SlashMode::Interfacing => 11,
+        SlashMode::Ramp => 12,
+        SlashMode::GameOver => 13,
+        SlashMode::Start => 14,
+        SlashMode::Buzzer => 15,
     }
 }
 

--- a/src/ui/toast.rs
+++ b/src/ui/toast.rs
@@ -1,0 +1,68 @@
+use gtk4::prelude::*;
+
+use crate::backend::AsusctlError;
+
+use super::AsusctlGuiWindow;
+
+const NOT_INSTALLED_TITLE: &str = "Couldn’t apply the change because asusctl is not installed";
+const SERVICE_NOT_RUNNING_TITLE: &str = "Couldn’t apply the change because asusd is not running";
+
+pub(crate) fn show_backend_error(
+    source: &impl IsA<gtk4::Widget>,
+    fallback_title: &str,
+    error: &AsusctlError,
+) {
+    let Some(root) = source.as_ref().root() else {
+        return;
+    };
+    let Ok(window) = root.downcast::<AsusctlGuiWindow>() else {
+        return;
+    };
+
+    window.show_error_toast(backend_error_title(error, fallback_title));
+}
+
+fn backend_error_title<'a>(error: &AsusctlError, fallback_title: &'a str) -> &'a str {
+    match error {
+        AsusctlError::NotInstalled => NOT_INSTALLED_TITLE,
+        AsusctlError::ServiceNotRunning => SERVICE_NOT_RUNNING_TITLE,
+        AsusctlError::CommandFailed(_) | AsusctlError::ParseError(_) => fallback_title,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FALLBACK: &str = "Couldn’t change the power profile";
+
+    #[test]
+    fn not_installed_overrides_fallback() {
+        assert_eq!(
+            backend_error_title(&AsusctlError::NotInstalled, FALLBACK),
+            NOT_INSTALLED_TITLE
+        );
+    }
+
+    #[test]
+    fn service_not_running_overrides_fallback() {
+        assert_eq!(
+            backend_error_title(&AsusctlError::ServiceNotRunning, FALLBACK),
+            SERVICE_NOT_RUNNING_TITLE
+        );
+    }
+
+    #[test]
+    fn command_failure_uses_fallback() {
+        let error = AsusctlError::CommandFailed("backend details".to_string());
+
+        assert_eq!(backend_error_title(&error, FALLBACK), FALLBACK);
+    }
+
+    #[test]
+    fn parse_failure_uses_fallback() {
+        let error = AsusctlError::ParseError("backend details".to_string());
+
+        assert_eq!(backend_error_title(&error, FALLBACK), FALLBACK);
+    }
+}

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -22,7 +22,7 @@ use super::{
 mod imp {
     use super::*;
     use adw::subclass::prelude::*;
-    use std::cell::RefCell;
+    use std::cell::{OnceCell, RefCell};
 
     #[derive(Debug, Default)]
     pub struct AsusctlGuiWindow {
@@ -30,6 +30,8 @@ mod imp {
         pub stack: RefCell<Option<gtk4::Stack>>,
         pub sidebar: RefCell<Option<adw::Sidebar>>,
         pub settings: RefCell<Option<gio::Settings>>,
+        pub toast_overlay: OnceCell<adw::ToastOverlay>,
+        pub active_error_toast: RefCell<Option<adw::Toast>>,
         // Store direct references to pages for refresh
         pub about_page: RefCell<Option<AboutPage>>,
         pub aura_page: RefCell<Option<AuraPage>>,
@@ -290,12 +292,15 @@ impl AsusctlGuiWindow {
         let loading_view = adw::ToolbarView::new();
         loading_view.add_top_bar(&loading_header);
         loading_view.set_content(Some(&spinner));
-        self.set_content(Some(&loading_view));
+
+        let toast_overlay = imp.toast_overlay.get_or_init(adw::ToastOverlay::new);
+        toast_overlay.set_child(Some(&loading_view));
+        self.set_content(Some(toast_overlay));
 
         // Setup actions
         self.setup_actions();
 
-        // Store references (split view swapped in once loading finishes)
+        // Store references (split view becomes the overlay child once loading finishes)
         imp.split_view.replace(Some(split_view));
         imp.stack.replace(Some(stack));
         imp.sidebar.replace(Some(sidebar));
@@ -377,9 +382,11 @@ impl AsusctlGuiWindow {
         imp.power_page.replace(Some(power_page));
         imp.slash_page.replace(Some(slash_page));
 
-        // Swap loading screen for the full split view
-        if let Some(split_view) = imp.split_view.borrow().as_ref() {
-            self.set_content(Some(split_view));
+        // Swap loading screen for the full split view while retaining the toast overlay
+        if let (Some(overlay), Some(split_view)) =
+            (imp.toast_overlay.get(), imp.split_view.borrow().as_ref())
+        {
+            overlay.set_child(Some(split_view));
         }
 
         // Determine startup page
@@ -432,6 +439,44 @@ impl AsusctlGuiWindow {
             window.close();
         });
         self.add_action(&quit_action);
+    }
+
+    pub(crate) fn show_error_toast(&self, title: &str) {
+        let imp = self.imp();
+        let Some(overlay) = imp.toast_overlay.get() else {
+            return;
+        };
+
+        let active_toast = imp.active_error_toast.borrow().clone();
+        let toast = if let Some(toast) = active_toast {
+            toast.set_title(title);
+            toast
+        } else {
+            let toast = adw::Toast::builder()
+                .title(title)
+                .priority(adw::ToastPriority::High)
+                .timeout(5)
+                .use_markup(false)
+                .build();
+            let window_weak = self.downgrade();
+            toast.connect_dismissed(move |dismissed_toast| {
+                let Some(window) = window_weak.upgrade() else {
+                    return;
+                };
+
+                let mut active_toast = window.imp().active_error_toast.borrow_mut();
+                if active_toast
+                    .as_ref()
+                    .is_some_and(|active_toast| active_toast == dismissed_toast)
+                {
+                    active_toast.take();
+                }
+            });
+            imp.active_error_toast.replace(Some(toast.clone()));
+            toast
+        };
+
+        overlay.add_toast(toast);
     }
 
     fn show_preferences_dialog(&self) {


### PR DESCRIPTION
## Summary

- Add one window-level native toast overlay and reuse the active error toast to avoid notification queues.
- Report failed user-initiated backend writes with concise action or known-cause messages while retaining technical details in logs.
- Re-read and restore affected Power, Aura, and Slash controls without recursively issuing writes.
- Add unit coverage for error-title selection; formatting, compilation, and all 104 tests pass.
